### PR TITLE
Add support for AMPHTML.

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,17 @@ Minified:
 
 Collapses boolean attributes (like `disabled`) to the minimized form.
 
+##### Options
+
+If your document uses [AMP](https://www.ampproject.org/), set the `amphtml` flag
+to collapse additonal, AMP-specific boolean attributes:
+
+```Json
+"collapseBooleanAttributes": {
+    "amphtml": true
+}
+```
+
 ##### Side effects
 
 This module could break your styles or JS if you use selectors with attributes:

--- a/lib/helpers.es6
+++ b/lib/helpers.es6
@@ -1,3 +1,21 @@
+const ampBoilerplateAttributes = [
+    'amp-boilerplate',
+    'amp4ads-boilerplate',
+    'amp4email-boilerplate'
+];
+
+export function isAmpBoilerplate(node) {
+    if (!node.attrs) {
+        return false;
+    }
+    for (let attr of ampBoilerplateAttributes) {
+        if (attr in node.attrs) {
+            return true;
+        }
+    }
+    return false;
+}
+
 export function isComment(content) {
     return (content || '').trim().search('<!--') === 0;
 }

--- a/lib/htmlnano.es6
+++ b/lib/htmlnano.es6
@@ -7,7 +7,9 @@ const defaultOptions = {
     removeEmptyAttributes: true,
     removeRedundantAttributes: false,
     collapseWhitespace: 'conservative',
-    collapseBooleanAttributes: true,
+    collapseBooleanAttributes: {
+        amphtml: false,
+    },
     mergeStyles: true,
     mergeScripts: true,
     minifyCss: {

--- a/lib/modules/collapseBooleanAttributes.es6
+++ b/lib/modules/collapseBooleanAttributes.es6
@@ -1,6 +1,8 @@
 // Source: https://github.com/kangax/html-minifier/issues/63
-const booleanAttributes = new Set([
+const htmlBooleanAttributes = new Set([
     'allowfullscreen',
+    'allowpaymentrequest',
+    'allowtransparency',
     'async',
     'autofocus',
     'autoplay',
@@ -43,11 +45,71 @@ const booleanAttributes = new Set([
     'visible'
 ]);
 
+const amphtmlBooleanAttributes = new Set([
+    '⚡',
+    'amp',
+    '⚡4ads',
+    'amp4ads',
+    '⚡4email',
+    'amp4email',
 
-export default function collapseBooleanAttributes(tree) {
+    'amp-custom',
+    'amp-boilerplate',
+    'amp4ads-boilerplate',
+    'amp4email-boilerplate',
+
+    'allow-blocked-ranges',
+    'amp-access-hide',
+    'amp-access-template',
+    'amp-keyframes',
+    'animate',
+    'arrows',
+    'data-block-on-consent',
+    'data-enable-refresh',
+    'data-multi-size',
+    'date-template',
+    'disable-double-tap',
+    'disable-session-states',
+    'disableremoteplayback',
+    'dots',
+    'expand-single-section',
+    'expanded',
+    'fallback',
+    'first',
+    'fullscreen',
+    'inline',
+    'lightbox',
+    'noaudio',
+    'noautoplay',
+    'noloading',
+    'once',
+    'open-after-clear',
+    'open-after-select',
+    'open-button',
+    'placeholder',
+    'preload',
+    'reset-on-refresh',
+    'reset-on-resize',
+    'resizable',
+    'rotate-to-fullscreen',
+    'second',
+    'standalone',
+    'stereo',
+    'submit-error',
+    'submit-success',
+    'submitting',
+    'subscriptions-actions',
+    'subscriptions-dialog'
+]);
+
+
+export default function collapseBooleanAttributes(tree, options, moduleOptions) {
     tree.match({attrs: true}, node => {
         for (let attrName of Object.keys(node.attrs)) {
-            if (booleanAttributes.has(attrName)) {
+            if (htmlBooleanAttributes.has(attrName)) {
+                node.attrs[attrName] = true;
+            }
+            if (moduleOptions.amphtml && node.attrs[attrName] === '' && amphtmlBooleanAttributes.has(attrName)) {
                 node.attrs[attrName] = true;
             }
         }

--- a/lib/modules/mergeStyles.es6
+++ b/lib/modules/mergeStyles.es6
@@ -1,3 +1,5 @@
+import { isAmpBoilerplate } from '../helpers';
+
 /* Merge multiple <style> into one */
 export default function mergeStyles(tree) {
     const styleNodes = {};
@@ -7,6 +9,10 @@ export default function mergeStyles(tree) {
         // Skip <style scoped></style>
         // https://developer.mozilla.org/en/docs/Web/HTML/Element/style
         if (nodeAttrs.scoped !== undefined) {
+            return node;
+        }
+
+        if (isAmpBoilerplate(node)) {
             return node;
         }
 

--- a/lib/modules/minifyCss.es6
+++ b/lib/modules/minifyCss.es6
@@ -1,10 +1,11 @@
+import { isAmpBoilerplate } from '../helpers';
 import cssnano from 'cssnano';
 
 /** Minify CSS with cssnano */
 export default function minifyCss(tree, options, cssnanoOptions) {
     let promises = [];
     tree.walk(node => {
-        if (node.tag === 'style' && node.content && node.content.length) {
+        if (isStyleNode(node)) {
             promises.push(processStyleNode(node, cssnanoOptions));
         } else if (node.attrs && node.attrs.style) {
             promises.push(processStyleAttr(node, cssnanoOptions));
@@ -14,6 +15,11 @@ export default function minifyCss(tree, options, cssnanoOptions) {
     });
 
     return Promise.all(promises).then(() => tree);
+}
+
+
+function isStyleNode(node) {
+    return node.tag === 'style' && !isAmpBoilerplate(node) && node.content && node.content.length;
 }
 
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,7 +1,19 @@
 import expect from 'expect';
-import { isComment, isConditionalComment } from '../lib/helpers';
+import { isAmpBoilerplate, isComment, isConditionalComment } from '../lib/helpers';
 
 describe('[helpers]', () => {
+    context('isAmpBoilerplate()', () => {
+        it('should detect AMP boilerplate', () => {
+            expect(isAmpBoilerplate({
+                tag: 'style',
+                attrs: {
+                    'amp-boilerplate': ''
+                },
+            })).toBe(true);
+            expect(isAmpBoilerplate({ tag: 'style' })).toBe(false);
+        });
+    });
+
     context('isComment()', () => {
         it('should detect HTML comments', () => {
             expect(isComment(' <!-- comment --> ')).toBe(true);

--- a/test/modules/collapseBooleanAttributes.js
+++ b/test/modules/collapseBooleanAttributes.js
@@ -2,7 +2,8 @@ import { init } from '../htmlnano';
 
 
 describe('collapseBooleanAttributes', () => {
-    const options = {collapseBooleanAttributes: true};
+    const options = {collapseBooleanAttributes: {}};
+    const optionsWithAmp = {collapseBooleanAttributes: { amphtml: true }};
 
     it('should collapse a boolean attribute with value', () => {
         return init(
@@ -27,6 +28,21 @@ describe('collapseBooleanAttributes', () => {
             '<a href="">link</a>',
             '<a href="">link</a>',
             options
+        );
+    });
+
+
+    it('should collapse AMP boolean attributes with empty value', () => {
+        return init(
+            '<script defer=""></script>' +
+            '<style amp-custom=""></style>' +
+            '<amp-video preload="metadata"></amp-video>',
+
+            '<script defer></script>' +
+            '<style amp-custom></style>' +
+            '<amp-video preload="metadata"></amp-video>',
+
+            optionsWithAmp
         );
     });
 });

--- a/test/modules/mergeStyles.js
+++ b/test/modules/mergeStyles.js
@@ -29,4 +29,28 @@ describe('mergeStyles', () => {
             html, html, options
         );
     });
+
+
+    it('should preserve amp-custom', () => {
+        return init(
+            '<style amp-custom>h1 { color: red }</style>' +
+            '<div>hello</div>' +
+            '<style amp-custom>div { color: blue }</style>',
+
+            '<style amp-custom="">h1 { color: red } div { color: blue }</style>' +
+            '<div>hello</div>',
+
+            options
+        );
+    });
+
+
+    it('should ignore AMP boilerplate', () => {
+        const html = `<style>h1 { color: red }</style>
+                      <div></div>
+                      <style amp-boilerplate="">div { color: blue }</style>`;
+        return init(
+            html, html, options
+        );
+    });
 });

--- a/test/modules/minifyCss.js
+++ b/test/modules/minifyCss.js
@@ -55,4 +55,14 @@ describe('minifyCss', () => {
             options
         );
     });
+
+
+    it('should ignore AMP boilerplate', () => {
+        const amphtml = '<style amp-boilerplate="">\nh1{color:red}</style>';
+        return init(
+            amphtml,
+            amphtml,
+            options
+        );
+    });
 });


### PR DESCRIPTION
Related issue: #57

- `mergeStyles` and `minifyCss` now ignores the AMP boilerplate (`<style amp-boilerplate>...</style>`).
- Added test to ensure `mergeStyles` preserves `amp-custom` attribute.
- Added `allowpaymentrequest` and `allowtransparency` to `collapseBooleanAttributes` (not AMP related).
- Added AMP-specific boolean attributes to `collapseBooleanAttributes`. These will only be collapsed when empty, since some of them are not exclusively boolean and this functionality needs to enabled via an option for this module.
- Updated README.