### PR TITLE
Remove old node versions from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ sudo: false
 language: node_js
 node_js:
   - stable
-  - "4"
-  - "5"
+  - "6"
   - "8"


### PR DESCRIPTION
Removed node versions 4 and 5 from `.travis.yml`, added 6.