### PR TITLE
Remove leak checking from mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint *.js lib/*.es6 lib/modules/*.es6 test/",
     "pretest": "npm run lint && npm run compile",
     "test": ":",
-    "posttest": "mocha --require babel-core/register --recursive --check-leaks --globals addresses",
+    "posttest": "mocha --require babel-core/register --recursive --globals addresses",
     "prepublish": "npm run compile"
   },
   "keywords": [


### PR DESCRIPTION
Per #49, tests are failing due to a leak in one of the dependencies.

Removing leak checking should at least make Travis more useful until #49 is fixed. We can revert this PR after that.