### PR TITLE
Disable minifyJs for ampSafe

### DIFF
--- a/lib/presets/ampSafe.es6
+++ b/lib/presets/ampSafe.es6
@@ -8,4 +8,5 @@ export default objectAssign({}, safePreset, {
     collapseBooleanAttributes: {
         amphtml: true,
     },
+    minifyJs: false,
 });


### PR DESCRIPTION
Turns out it causes issues with valid AMP like `<button on="tap:something">` as it removes the `tap:`. Also not really needed since AMP has no custom JavaScript in the HTML.