### PR TITLE
Fix bug when tag === false

### DIFF
--- a/lib/modules/collapseBooleanAttributes.es6
+++ b/lib/modules/collapseBooleanAttributes.es6
@@ -106,6 +106,10 @@ const amphtmlBooleanAttributes = new Set([
 export default function collapseBooleanAttributes(tree, options, moduleOptions) {
     tree.match({attrs: true}, node => {
         for (let attrName of Object.keys(node.attrs)) {
+            if (!node.tag) {
+                continue;
+            }
+
             if (node.tag.search('a-') === 0 && attrName === 'visible') {
                 continue;
             }


### PR DESCRIPTION
It seems there's an edge-case where another posthtml plugin produces (I believe valid) tree that looks like this:

```
{
  tag: false,
  attrs: {
    something: 'abc'
  },
  content: [
   ...
  ]
}
```

In this case, a placeholder element was replaced by changing `tag` to false, but the `attrs` property remained. This cases `collapseBooleanAttributes` to throw `TypeError: node.tag.search is not a function` since `node.tag` is a boolean and doesn't have the `search` property.