### PR TITLE
Add "crossorigin" to boolean attributes

### DIFF
--- a/lib/modules/collapseBooleanAttributes.es6
+++ b/lib/modules/collapseBooleanAttributes.es6
@@ -9,6 +9,7 @@ const htmlBooleanAttributes = new Set([
     'checked',
     'compact',
     'controls',
+    'crossorigin',
     'declare',
     'default',
     'defaultchecked',


### PR DESCRIPTION
> An invalid keyword and an empty string will be handled as the `anonymous` keyword.

[Source](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes)