### PR TITLE
Add removeUnusedCss module (uncss based)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,53 @@ Minified:
 <img src="foo.jpg" alt="">
 ```
 
+### removeUnusedCss
+Removes unused CSS with [uncss](https://github.com/uncss/uncss) inside `<style>` tags.
+
+##### Options
+See [the documentation of uncss](https://github.com/uncss/uncss) for all supported options.
+
+uncss options can be passed directly to the `removeUnusedCss` module:
+```js
+htmlnano.process(html, {
+    removeUnusedCss: {
+        ignore: ['.do-not-remove']
+    }
+});
+```
+
+The following uncss options are ignored if passed to the module:
+
+-   `stylesheets`
+-   `ignoreSheets`
+-   `raw`
+
+##### Example
+Source:
+```html
+<div class="b">
+    <style>
+        .a {
+            margin: 10px 10px 10px 10px;
+        }
+        .b {
+            color: #ff0000;
+        }
+    </style>
+</div>
+```
+
+Optimized:
+```html
+<div class="b">
+    <style>
+        .b {
+            color: #ff0000;
+        }
+    </style>
+</div>
+```
+
 
 ### minifyCss
 Minifies CSS with [cssnano](http://cssnano.co/) inside `<style>` tags and `style` attributes.

--- a/lib/helpers.es6
+++ b/lib/helpers.es6
@@ -23,3 +23,11 @@ export function isComment(content) {
 export function isConditionalComment(content) {
     return (content || '').trim().search(/<!--\[if/) === 0;
 }
+
+export function isStyleNode(node) {
+    return node.tag === 'style' && !isAmpBoilerplate(node) && 'content' in node && node.content.length > 0;
+}
+
+export function extractCssFromStyleNode(node) {
+    return Array.isArray(node.content) ? node.content.join(' ') : node.content;
+}

--- a/lib/modules/minifyCss.es6
+++ b/lib/modules/minifyCss.es6
@@ -1,4 +1,4 @@
-import { isAmpBoilerplate } from '../helpers';
+import { isStyleNode, extractCssFromStyleNode } from '../helpers';
 import cssnano from 'cssnano';
 
 const postcssOptions = {
@@ -25,13 +25,8 @@ export default function minifyCss(tree, options, cssnanoOptions) {
 }
 
 
-function isStyleNode(node) {
-    return node.tag === 'style' && !isAmpBoilerplate(node) && node.content && node.content.length;
-}
-
-
 function processStyleNode(styleNode, cssnanoOptions) {
-    const css = Array.isArray(styleNode.content) ? styleNode.content.join(' ') : styleNode.content;
+    const css = extractCssFromStyleNode(styleNode);
     return cssnano
         .process(css, postcssOptions, cssnanoOptions)
         .then(result => styleNode.content = [result.css]);

--- a/lib/modules/removeUnusedCss.es6
+++ b/lib/modules/removeUnusedCss.es6
@@ -1,0 +1,58 @@
+import { isStyleNode, extractCssFromStyleNode } from '../helpers';
+import uncss from 'uncss';
+import render from 'posthtml-render';
+
+
+// These options must be set and shouldn't be overriden to ensure uncss doesn't look at linked stylesheets.
+const uncssOptions = {
+    ignoreSheets: [/\s*/],
+    stylesheets: [],
+};
+
+/** Remove unused CSS using uncss */
+export default function removeUnusedCss(tree, options, uncssOptions) {
+    let promises = [];
+    const html = render(tree);
+    tree.walk(node => {
+        if (isStyleNode(node)) {
+            promises.push(processStyleNode(html, node, uncssOptions));
+        }
+        return node;
+    });
+
+    return Promise.all(promises).then(() => tree);
+}
+
+
+function processStyleNode(html, styleNode, uncssOptions) {
+    const css = extractCssFromStyleNode(styleNode);
+
+    return runUncss(html, css, uncssOptions).then(css => {
+        // uncss may have left some style tags empty
+        if (css.trim().length === 0) {
+            styleNode.tag = false;
+            styleNode.content = [];
+            return;
+        }
+        styleNode.content = [css];
+    });
+}
+
+
+function runUncss(html, css, userOptions) {
+    if (typeof userOptions !== 'object') {
+        userOptions = {};
+    }
+
+    const options = Object.assign({}, userOptions, uncssOptions);
+    return new Promise((resolve, reject) => {
+        options.raw = css;
+        uncss(html, options, (error, output) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve(output);
+        });
+    });
+}

--- a/lib/presets/max.es6
+++ b/lib/presets/max.es6
@@ -8,4 +8,8 @@ export default objectAssign({}, safePreset, {
     collapseWhitespace: 'all',
     removeComments: 'all',
     removeRedundantAttributes: true,
+    removeUnusedCss: {},
+    minifyCss: {
+        preset: 'default',
+    }
 });

--- a/lib/presets/safe.es6
+++ b/lib/presets/safe.es6
@@ -11,6 +11,7 @@ export default {
     deduplicateAttributeValues: true,
     mergeScripts: true,
     mergeStyles: true,
+    removeUnusedCss: false,
     minifyCss: {
         preset: 'default',
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "posthtml": "^0.11.3",
     "posthtml-render": "^1.1.4",
     "svgo": "^1.0.5",
-    "terser": "^3.8.2"
+    "terser": "^3.8.2",
+    "uncss": "^0.16.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,14 +1,12 @@
 import expect from 'expect';
-import { isAmpBoilerplate, isComment, isConditionalComment } from '../lib/helpers';
+import { isAmpBoilerplate, isComment, isConditionalComment, isStyleNode, extractCssFromStyleNode } from '../lib/helpers';
 
 describe('[helpers]', () => {
     context('isAmpBoilerplate()', () => {
         it('should detect AMP boilerplate', () => {
             expect(isAmpBoilerplate({
                 tag: 'style',
-                attrs: {
-                    'amp-boilerplate': ''
-                },
+                attrs: { 'amp-boilerplate': '' },
             })).toBe(true);
             expect(isAmpBoilerplate({ tag: 'style' })).toBe(false);
         });
@@ -27,6 +25,36 @@ describe('[helpers]', () => {
             expect(isConditionalComment(' <!--[if IE 6]><p>You are using IE 6<![endif]-->')).toBe(true);
             expect(isConditionalComment(' <!-- comment --> ')).toBe(false);
             expect(isConditionalComment('Some text')).toBe(false);
+        });
+    });
+
+    context('isStyleNode()', () => {
+        it('should detect <style> nodes', () => {
+            expect(isStyleNode({ tag: 'style', content: 'abc' })).toBe(true);
+            expect(isStyleNode({ tag: 'style', content: ['a', 'b'] })).toBe(true);
+            expect(isStyleNode({ tag: 'style' })).toBe(false);
+            expect(isStyleNode({ tag: 'div' })).toBe(false);
+            expect(isStyleNode({
+                tag: 'style',
+                content: 'abc',
+                attrs: { 'amp-boilerplate': '' },
+            })).toBe(false);
+        });
+    });
+
+    context('extractCssFromStyleNode()', () => {
+        it('should extract CSS from <style> node', () => {
+            expect(extractCssFromStyleNode({
+                tag: 'style',
+                content: 'abc',
+            })).toBe('abc');
+            expect(extractCssFromStyleNode({
+                tag: 'style',
+                content: [
+                    'abc',
+                    'def',
+                ],
+            })).toBe('abc def');
         });
     });
 });

--- a/test/modules/removeUnusedCss.js
+++ b/test/modules/removeUnusedCss.js
@@ -1,0 +1,68 @@
+import { init } from '../htmlnano';
+import maxPreset from '../../lib/presets/max';
+
+
+describe('removeUnusedCss', function () {
+    this.timeout(3000);
+
+    const options = {
+        removeUnusedCss: maxPreset.removeUnusedCss,
+    };
+    const html = `<div><style>
+        div.b {
+            padding: 10px;
+            border-radius: 10px;
+        }
+        .b {
+            color: red;
+        }
+        .c {
+            color: #123;
+        }
+    </style></div><p class="b">hello</p><style>.d{margin:auto}</style>`;
+
+
+    it('should remove unused CSS inside <style>', () => {
+        return init(
+            html,
+            `<div><style>
+        .b {
+            color: red;
+        }
+    </style></div><p class="b">hello</p>`,
+            options
+        );
+    });
+
+
+    it('should pass options to uncss', () => {
+        return init(
+            html,
+            `<div><style>
+        .b {
+            color: red;
+        }
+        .c {
+            color: #123;
+        }
+    </style></div><p class="b">hello</p>`,
+            {
+                removeUnusedCss: {
+                    ignore: ['.c']
+                }
+            }
+        );
+    });
+
+
+    it('should work with minifyCss', () => {
+        return init(
+            html,
+            '<div><style>.b{color:red}</style></div><p class="b">hello</p>',
+            {
+                removeUnusedCss: maxPreset.removeUnusedCss,
+                minifyCss: {},
+            }
+        );
+    });
+});


### PR DESCRIPTION
Fixes #36.

I originally wanted to make this part of `minifyCss`, but that'd break compatibility (since the module options would need to include both options for cssnano and for uncss).

This seems to work well based on a few tests. Might be an overkill in terms of performance, but I think it's a good idea to rely on a field-tested library like uncss.