### PR TITLE
Replace Uncss by PurgeCSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,25 +273,25 @@ Minified:
 ```
 
 ### removeUnusedCss
-Removes unused CSS with [uncss](https://github.com/uncss/uncss) inside `<style>` tags.
+Removes unused CSS with [PurgeCSS](https://github.com/FullHuman/purgecss) inside `<style>` tags.
 
 ##### Options
-See [the documentation of uncss](https://github.com/uncss/uncss) for all supported options.
+See [the documentation of PurgeCSS](https://www.purgecss.com) for all supported options.
 
-uncss options can be passed directly to the `removeUnusedCss` module:
+PurgeCSS options can be passed directly to the `removeUnusedCss` module:
 ```js
 htmlnano.process(html, {
     removeUnusedCss: {
-        ignore: ['.do-not-remove']
+        whitelist: ['.do-not-remove']
     }
 });
 ```
 
 The following uncss options are ignored if passed to the module:
 
--   `stylesheets`
--   `ignoreSheets`
--   `raw`
+-   `content`
+-   `css`
+-   `extractors`
 
 ##### Example
 Source:

--- a/lib/htmlnano.es6
+++ b/lib/htmlnano.es6
@@ -1,4 +1,3 @@
-import objectAssign from 'object-assign';
 import posthtml from 'posthtml';
 import safePreset from './presets/safe';
 import ampSafePreset from './presets/ampSafe';
@@ -7,7 +6,7 @@ import maxPreset from './presets/max';
 
 function htmlnano(options = {}, preset = safePreset) {
     return function minifier(tree) {
-        options = objectAssign({}, preset, options);
+        options = Object.assign({}, preset, options);
         let promise = Promise.resolve(tree);
         for (let moduleName of Object.keys(options)) {
             if (! options[moduleName]) {

--- a/lib/presets/ampSafe.es6
+++ b/lib/presets/ampSafe.es6
@@ -1,10 +1,9 @@
-import objectAssign from 'object-assign';
 import safePreset from './safe';
 
 /**
  * A safe preset for AMP pages (https://www.ampproject.org)
  */
-export default objectAssign({}, safePreset, {
+export default Object.assign({}, safePreset, {
     collapseBooleanAttributes: {
         amphtml: true,
     },

--- a/lib/presets/max.es6
+++ b/lib/presets/max.es6
@@ -1,10 +1,9 @@
-import objectAssign from 'object-assign';
 import safePreset from './safe';
 
 /**
  * Maximal minification (might break some pages)
  */
-export default objectAssign({}, safePreset, {
+export default Object.assign({}, safePreset, {
     collapseWhitespace: 'all',
     removeComments: 'all',
     removeRedundantAttributes: true,

--- a/package.json
+++ b/package.json
@@ -34,12 +34,11 @@
   "dependencies": {
     "cssnano": "^4.1.10",
     "normalize-html-whitespace": "^1.0.0",
-    "object-assign": "^4.0.1",
-    "posthtml": "^0.11.4",
+    "posthtml": "^0.12.0",
+    "posthtml-render": "^1.1.5",
     "purgecss": "^1.4.0",
-    "svgo": "^1.2.2",
-    "terser": "^4.1.2",
-    "uncss": "^0.17.0"
+    "svgo": "^1.3.0",
+    "terser": "^4.1.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "normalize-html-whitespace": "^1.0.0",
     "object-assign": "^4.0.1",
     "posthtml": "^0.11.4",
-    "posthtml-render": "^1.1.5",
+    "purgecss": "^1.4.0",
     "svgo": "^1.2.2",
     "terser": "^4.1.2",
     "uncss": "^0.17.0"

--- a/test/modules/minifyJs.js
+++ b/test/modules/minifyJs.js
@@ -1,4 +1,3 @@
-import objectAssign from 'object-assign';
 import { init } from '../htmlnano';
 import safePreset from '../../lib/presets/safe';
 import ampSafePreset from '../../lib/presets/ampSafe';
@@ -66,7 +65,7 @@ describe('minifyJs', () => {
         return init(
             '<script>foo["bar"] = 5;</script>',
             '<script>foo["bar"]=5;</script>',
-            objectAssign({}, options, {
+            Object.assign({}, options, {
                 minifyJs: {
                     compress: {
                         properties: false,

--- a/test/modules/removeUnusedCss.js
+++ b/test/modules/removeUnusedCss.js
@@ -9,7 +9,7 @@ describe('removeUnusedCss', function () {
         removeUnusedCss: maxPreset.removeUnusedCss,
     };
     const html = `<div><style>
-        div.b {
+        div.r {
             padding: 10px;
             border-radius: 10px;
         }
@@ -35,7 +35,7 @@ describe('removeUnusedCss', function () {
     });
 
 
-    it('should pass options to uncss', () => {
+    it('should pass options to purgeCSS', () => {
         return init(
             html,
             `<div><style>
@@ -48,7 +48,7 @@ describe('removeUnusedCss', function () {
     </style></div><p class="b">hello</p>`,
             {
                 removeUnusedCss: {
-                    ignore: ['.c']
+                    whitelist: ['c']
                 }
             }
         );


### PR DESCRIPTION
Hey,

I am using tailwindcss those days and purgeCSS is more commonly used than uncss. I decided to go ahead and try to replace it to see how it goes. The results are quite similar when it comes to removing unused CSS although uncss can work better in some circumstances. Uncss is a bit slower on my laptop, the tests run at 970ms for uncss and about 75ms for purgeCSS.

Let me know what you think about the change.

I remove `uncss` as dependencies in the process. I also removed `object-assign`. Object.assign is available in Nodejs 4+ so I'm not sure if it's still necessary to keep this dependency. I updated the other dependencies as well.