### PR TITLE
Adopt some ES6 syntaxs

### DIFF
--- a/lib/helpers.es6
+++ b/lib/helpers.es6
@@ -8,7 +8,7 @@ export function isAmpBoilerplate(node) {
     if (!node.attrs) {
         return false;
     }
-    for (let attr of ampBoilerplateAttributes) {
+    for (const attr of ampBoilerplateAttributes) {
         if (attr in node.attrs) {
             return true;
         }

--- a/lib/htmlnano.es6
+++ b/lib/htmlnano.es6
@@ -6,7 +6,7 @@ import maxPreset from './presets/max';
 
 function htmlnano(options = {}, preset = safePreset) {
     return function minifier(tree) {
-        options = Object.assign({}, preset, options);
+        options = { ...preset, ...options };
         let promise = Promise.resolve(tree);
         for (let moduleName of Object.keys(options)) {
             if (! options[moduleName]) {

--- a/lib/htmlnano.es6
+++ b/lib/htmlnano.es6
@@ -8,7 +8,7 @@ function htmlnano(options = {}, preset = safePreset) {
     return function minifier(tree) {
         options = { ...preset, ...options };
         let promise = Promise.resolve(tree);
-        for (let moduleName of Object.keys(options)) {
+        for (const moduleName of Object.keys(options)) {
             if (! options[moduleName]) {
                 // The module is disabled
                 continue;

--- a/lib/modules/collapseBooleanAttributes.es6
+++ b/lib/modules/collapseBooleanAttributes.es6
@@ -105,7 +105,7 @@ const amphtmlBooleanAttributes = new Set([
 
 export default function collapseBooleanAttributes(tree, options, moduleOptions) {
     tree.match({attrs: true}, node => {
-        for (let attrName of Object.keys(node.attrs)) {
+        for (const attrName of Object.keys(node.attrs)) {
             if (!node.tag) {
                 continue;
             }

--- a/lib/modules/mergeScripts.es6
+++ b/lib/modules/mergeScripts.es6
@@ -31,7 +31,7 @@ export default function mergeScripts(tree) {
         return node;
     });
 
-    for (let scriptKey of Object.keys(scriptNodesIndex)) {
+    for (const scriptKey of Object.keys(scriptNodesIndex)) {
         let scriptNodes = scriptNodesIndex[scriptKey];
         let lastScriptNode = scriptNodes.pop();
         scriptNodes.reverse().forEach(scriptNode => {

--- a/lib/modules/minifyJs.es6
+++ b/lib/modules/minifyJs.es6
@@ -66,7 +66,7 @@ function processNodeWithOnAttrs(node, terserOptions) {
     const jsWrapperStart = 'function _(){';
     const jsWrapperEnd = '}';
 
-    for (let attrName of Object.keys(node.attrs || {})) {
+    for (const attrName of Object.keys(node.attrs || {})) {
         if (attrName.search('on') !== 0) {
             continue;
         }

--- a/lib/modules/removeRedundantAttributes.es6
+++ b/lib/modules/removeRedundantAttributes.es6
@@ -40,7 +40,7 @@ export default function removeRedundantAttributes(tree) {
     tree.match({tag: tagMatchRegExp}, node => {
         const tagRedundantAttributes = redundantAttributes[node.tag];
         node.attrs = node.attrs || {};
-        for (let redundantAttributeName of Object.keys(tagRedundantAttributes)) {
+        for (const redundantAttributeName of Object.keys(tagRedundantAttributes)) {
             let tagRedundantAttributeValue = tagRedundantAttributes[redundantAttributeName];
             let isRemove = false;
             if (typeof tagRedundantAttributeValue === 'function') {

--- a/lib/modules/removeUnusedCss.es6
+++ b/lib/modules/removeUnusedCss.es6
@@ -28,7 +28,7 @@ function runUncss(html, css, userOptions) {
         userOptions = {};
     }
 
-    const options = Object.assign({}, userOptions, uncssOptions);
+    const options = { ...userOptions, ...uncssOptions };
     return new Promise((resolve, reject) => {
         options.raw = css;
         uncss(html, options, (error, output) => {
@@ -75,7 +75,8 @@ function runPurgecss(tree, css, userOptions) {
         userOptions = {};
     }
 
-    const options = Object.assign({}, userOptions, {
+    const options = {
+        ...userOptions,
         content: [{
             raw: tree,
             extension: 'html'
@@ -88,7 +89,7 @@ function runPurgecss(tree, css, userOptions) {
             extractor: purgeFromHtml(tree),
             extensions: ['html']
         }]
-    });
+    };
 
     return new Purgecss()
         .purge(options)

--- a/lib/presets/ampSafe.es6
+++ b/lib/presets/ampSafe.es6
@@ -3,9 +3,9 @@ import safePreset from './safe';
 /**
  * A safe preset for AMP pages (https://www.ampproject.org)
  */
-export default Object.assign({}, safePreset, {
+export default { ...safePreset,
     collapseBooleanAttributes: {
         amphtml: true,
     },
     minifyJs: false,
-});
+};

--- a/lib/presets/max.es6
+++ b/lib/presets/max.es6
@@ -3,7 +3,7 @@ import safePreset from './safe';
 /**
  * Maximal minification (might break some pages)
  */
-export default Object.assign({}, safePreset, {
+export default { ...safePreset,
     collapseWhitespace: 'all',
     removeComments: 'all',
     removeRedundantAttributes: true,
@@ -12,4 +12,4 @@ export default Object.assign({}, safePreset, {
         preset: 'default',
     },
     minifySvg: {},
-});
+};


### PR DESCRIPTION
- Use spread syntax replacing Object.assign
  - When first parameter of `Object.assign` is an empty plain object, it will be slower than spread syntax.
  - Spread in object literals is an ES2018 feature and is supported since Node.js 8.3.0.
- Use `const` instead of `let` in `for..of` loop
- Unit tests are passed & eslint is happy