### PR TITLE
Add a more aggressive whitespace removal option to the collapseWhitespace plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,29 +202,44 @@ Collapses redundant white spaces (including new lines). It doesn’t affect whit
 
 ##### Options
 - `conservative` — collapses all redundant white spaces to 1 space (default)
+- `aggressive` — removes newlines and tabs, collapses remaining whitespaces to 1 space.
 - `all` — collapses all redundant white spaces
 
 ##### Side effects
+*aggressive*
+
+`<i>hello</i>
+<i>world</i>` after minification will be rendered as `helloworld`.
+To prevent this include at least one real space character between the tags.
+
+*all*
 `<i>hello</i> <i>world</i>` after minification will be rendered as `helloworld`.
-To prevent that use `conservative` option (this is the default option).
+To prevent that use either the default `conservative` option, or the `aggressive` option.
 
 ##### Example
 Source:
 ```html
 <div>
     hello  world!
+    \t<a href="#">answer</a>
     <style>div  { color: red; }  </style>
+\t\t<main></main>
 </div>
 ```
 
 Minified (with `all`):
 ```html
-<div>hello world!<style>div  { color: red; }  </style></div>
+<div>hello world!<a href="#">answer</a><style>div  { color: red; }  </style><main></main></div>
+```
+
+Minified (with `aggressive`):
+```html
+<div> hello world! <a href="#">answer</a> <style>div  { color: red; }  </style><main></main></div>
 ```
 
 Minified (with `conservative`):
 ```html
-<div> hello world! <style>div  { color: red; }  </style> </div>
+<div> hello world! <a href="#">answer</a> <style>div  { color: red; }  </style> <main></main> </div>
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -206,13 +206,12 @@ Collapses redundant white spaces (including new lines). It doesn’t affect whit
 - `all` — collapses all redundant white spaces
 
 ##### Side effects
-*aggressive*
-
+*aggressive*  
 `<i>hello</i>
 <i>world</i>` after minification will be rendered as `helloworld`.
 To prevent this include at least one real space character between the tags.
 
-*all*
+*all*  
 `<i>hello</i> <i>world</i>` after minification will be rendered as `helloworld`.
 To prevent that use either the default `conservative` option, or the `aggressive` option.
 

--- a/lib/modules/collapseWhitespace.es6
+++ b/lib/modules/collapseWhitespace.es6
@@ -1,4 +1,3 @@
-import normalizeWhitespace from 'normalize-html-whitespace';
 import { isComment } from '../helpers';
 
 const noWhitespaceCollapseElements = new Set([
@@ -8,11 +7,15 @@ const noWhitespaceCollapseElements = new Set([
     'textarea'
 ]);
 
+const indentPattern = /[\f\n\r\t\v]{1,}/g;
+const whitespacePattern = /[\f\n\r\t\v ]{1,}/g;
+const NONE = '';
+const SINGLE_SPACE = ' ';
+const validOptions = ['all', 'aggressive', 'conservative'];
+
 /** Collapses redundant whitespaces */
 export default function collapseWhitespace(tree, options, collapseType, tag) {
-    if (collapseType !== 'all') {
-        collapseType = 'conservative';
-    }
+    collapseType = (collapseType && validOptions.some(o=>o === collapseType)) ? collapseType : 'conservative';
 
     tree.forEach((node, index) => {
         if (typeof node === 'string' && !isComment(node)) {
@@ -33,7 +36,16 @@ export default function collapseWhitespace(tree, options, collapseType, tag) {
 
 
 function collapseRedundantWhitespaces(text, collapseType, isTopLevel = false) {
-    text = text && text.length > 0 ? normalizeWhitespace(text) : '';
+    if (!text || text.length === 0) {
+        return NONE;
+    }
+
+    if (collapseType === 'aggressive') {
+        text = text.replace(indentPattern, NONE);
+    }
+
+    text = text.replace(whitespacePattern, SINGLE_SPACE);
+
     if (collapseType === 'all' || isTopLevel) {
         text = text.trim();
     }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "cssnano": "^4.1.10",
-    "normalize-html-whitespace": "^1.0.0",
     "posthtml": "^0.13.1",
     "posthtml-render": "^1.2.2",
     "purgecss": "^2.3.0",

--- a/test/modules/collapseWhitespace.js
+++ b/test/modules/collapseWhitespace.js
@@ -5,9 +5,31 @@ import maxPreset from '../../lib/presets/max';
 
 describe('collapseWhitespace', () => {
     const html = ` <div>
-            <b> hello  world! </b>
-      </div>  `;
+            <b> hello  world! </b><a>other link
+	</a>
+	  </div>  `;
 
+    const documentationHtml = `<div>
+    hello  world!
+    	<a href="#">answer</a>
+    <style>div  { color: red; }  </style>
+		<main></main>
+</div>`;
+
+    const inviolateTags = 'comments, <script>, <style>, <pre>, <textarea>';
+    const inviolateTagsHtml = `<script> alert() </script>  <style>.foo  {}</style> <pre> hello <b> , </b> </pre>
+      <div> <!--  hello   world  --> </div>
+	  <textarea> world! </textarea>`;
+
+    const topLevelTags = 'top-level tags (html, head, body)';
+    const topLevelTagsHtml = ` <html>
+                    <head>
+                        <title> Test </title>
+                        <script> </script>
+                    </head>
+                    <body>
+                    </body>
+                </html> `;
 
     context('all', () => {
         const options = {
@@ -17,18 +39,72 @@ describe('collapseWhitespace', () => {
         it('should collapse redundant whitespaces', () => {
             return init(
                 html,
-                '<div><b>hello world!</b></div>',
+                '<div><b>hello world!</b><a>other link</a></div>',
+                options
+            );
+        });
+		
+        it('should not collapse whitespaces inside ' + inviolateTags, () => {
+            return init(
+                inviolateTagsHtml,
+                '<script> alert() </script><style>.foo  {}</style><pre> hello <b> , </b> </pre>' +
+                '<div><!--  hello   world  --></div><textarea> world! </textarea>',
                 options
             );
         });
 
-        it('should not collapse whitespaces inside comments, <script>, <style>, <pre>, <textarea>', () => {
+        it('should collapse whitespaces between ' + topLevelTags, () => {
             return init(
-                `<script> alert() </script>  <style>.foo  {}</style> <pre> hello <b> , </b> </pre>
-                  <div> <!--  hello   world  --> </div>
-                  <textarea> world! </textarea>`,
+                topLevelTagsHtml,
+                '<html><head><title>Test</title><script> </script></head><body></body></html>',
+                options
+            );
+        });
+
+        it('renders the documentation example correctly', () => {
+            return init(
+                documentationHtml,
+                '<div>hello world!<a href="#">answer</a><style>div  { color: red; }  </style><main></main></div>',
+                options
+            );
+        });
+    });
+	
+	
+    context('aggressive', () => {
+        const options = {
+            collapseWhitespace: 'aggressive',
+        };
+
+        it('should collapse redundant whitespaces and eliminate indentation (tabs, newlines, etc)', () => {
+            return init(
+                html,
+                '<div> <b> hello world! </b><a>other link</a> </div>',
+                options
+            );
+        });
+
+        it('should not collapse whitespaces inside ' + inviolateTags, () => {
+            return init(
+                inviolateTagsHtml,
                 '<script> alert() </script><style>.foo  {}</style><pre> hello <b> , </b> </pre>' +
-                '<div><!--  hello   world  --></div><textarea> world! </textarea>',
+                '<div> <!--  hello   world  --> </div><textarea> world! </textarea>',
+                options
+            );
+        });
+
+        it('should collapse whitespaces between ' + topLevelTags, () => {
+            return init(
+                topLevelTagsHtml,
+                '<html><head><title> Test </title><script> </script></head><body> </body></html>',
+                options
+            );
+        });
+
+        it('renders the documentation example correctly', () => {
+            return init(
+                documentationHtml,
+                '<div> hello world! <a href="#">answer</a> <style>div  { color: red; }  </style><main></main></div>',
                 options
             );
         });
@@ -43,22 +119,32 @@ describe('collapseWhitespace', () => {
         it('should collapse to 1 space', () => {
             return init(
                 html,
-                '<div> <b> hello world! </b> </div>',
+                '<div> <b> hello world! </b><a>other link </a> </div>',
                 options
             );
         });
 
-        it('should collapse whitespaces between top-level tags (html, head, body)', () => {
+        it('should collapse whitespaces between ' + topLevelTags, () => {
             return init(
-                ` <html>
-                    <head>
-                        <title> Test </title>
-                        <script> </script>
-                    </head>
-                    <body>
-                    </body>
-                </html> `,
+                topLevelTagsHtml,
                 '<html><head><title> Test </title><script> </script></head><body> </body></html>',
+                options
+            );
+        });
+
+        it('should not collapse whitespaces inside ' + inviolateTags, () => {
+            return init(
+                inviolateTagsHtml,
+                '<script> alert() </script><style>.foo  {}</style><pre> hello <b> , </b> </pre>' +
+                '<div> <!--  hello   world  --> </div><textarea> world! </textarea>',
+                options
+            );
+        });
+
+        it('renders the documentation example correctly', () => {
+            return init(
+                documentationHtml,
+                '<div> hello world! <a href="#">answer</a> <style>div  { color: red; }  </style> <main></main> </div>',
                 options
             );
         });


### PR DESCRIPTION
I would like to propose an addition/change to the 'collapseWhitespace' plugin to more aggressively remove semantically redundant whitespace.

I saw, looking at the output of my minified code, lots of spaces being introduced where none existed in my input. These turned out to be a translation of the indentation/newlines into a single space. Since almost all of the markup was structural none of those spaces were adding anything of value.

Therefore I suggest that a new 'aggressive' mode be introduced that removes structural/incidental whitespace such as this. Actual space characters can be collapsed but should not be removed as they are essential between inline tags (e.g. title&lt;/b&gt; &lt;i&gt;part).

This pull request is a first attempt at implementing such behaviour.

Is this something you would consider for inclusion in the main htmlnano project?

NOTE: a small behavioural change was introduced to match the documentation - a single space now replaces individual newlines/tabs. I don't think this should have any impact on downstream consumers since html generally allows whitespace to be collapsed/replaced.