### PR TITLE
Feat: sort values inside list-like attributes

### DIFF
--- a/lib/modules/sortAttributesWithLists.es6
+++ b/lib/modules/sortAttributesWithLists.es6
@@ -1,0 +1,25 @@
+import { attributesWithLists } from './collapseAttributeWhitespace';
+
+/** Sort values inside list-like attributes (e.g. class, rel) */
+export default function collapseAttributeWhitespace(tree) {
+    tree.walk(node => {
+        if (! node.attrs) {
+            return node;
+        }
+
+        Object.keys(node.attrs).forEach(attrName => {
+            const attrNameLower = attrName.toLowerCase();
+            if (! attributesWithLists.has(attrNameLower)) {
+                return;
+            }
+
+            const attrValues = node.attrs[attrName].split(/\s/);
+
+            node.attrs[attrName] = attrValues.sort().join(' ');
+        });
+
+        return node;
+    });
+
+    return tree;
+}

--- a/lib/presets/safe.es6
+++ b/lib/presets/safe.es6
@@ -26,4 +26,5 @@ export default {
     removeEmptyAttributes: true,
     removeRedundantAttributes: false,
     removeComments: 'safe',
+    sortAttributesWithLists: true,
 };

--- a/test/modules/sortAttributesWithLists.js
+++ b/test/modules/sortAttributesWithLists.js
@@ -1,0 +1,16 @@
+import { init } from '../htmlnano';
+import safePreset from '../../lib/presets/safe';
+
+describe('sortAttributesWithLists', () => {
+    const options = {
+        sortAttributesWithLists: safePreset.sortAttributesWithLists,
+    };
+
+    it('it sort values from list-like attributes', () => {
+        return init(
+            '<a class="foo baz bar">click</a>',
+            '<a class="bar baz foo">click</a>',
+            options
+        );
+    });
+});


### PR DESCRIPTION
The feature won't impact the plain-text size of the output. It is designed to improve the compression ratio of gzip/brotli used in HTTP compression since it forms long repetitive chains of characters.

The document will be updated by another PR after this one is merged.