### PR TITLE
Docs: add sortAttributesWithLists

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,21 @@ const options = {
 
 `options` is an object with all options that were passed to the plugin.
 
+### sortAttributesWithLists
+Sort values in list-like attributes (`class`, `rel`, `ping`).
+
+The module won't impact the plain-text size of the output. However it will improve the compression ratio of gzip/brotli used in HTTP compression.
+
+##### Example
+Source:
+```html
+<div class="foo baz bar">click</div>
+```
+
+Processed:
+```html
+<div class="bar baz foo">click</div>
+```
 
 ## Contribute
 Since the minifier is modular, it's very easy to add new modules:


### PR DESCRIPTION
Add documents for #95.

BTW, I notice that the [contributing guide](https://github.com/posthtml/htmlnano#contribute) is outdated. There is no `the modules array` anymore, modules are now loaded automatically according to `options` and `presets`. I can bring up another PR to update the contributing guide.