### PR TITLE
Docs: update contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ Since the minifier is modular, it's very easy to add new modules:
 
 1. Create a ES6-file inside `lib/modules/` with a function that does some minification. For example you can check [`lib/modules/example.es6`](https://github.com/posthtml/htmlnano/blob/master/lib/modules/example.es6).
 
-2. Add the module in [the modules array](https://github.com/posthtml/htmlnano/blob/master/lib/htmlnano.es6#L5). The modules are applied from top to bottom. So you can choose the order for your module.
+2. Add the module's name into one of those [presets](https://github.com/posthtml/htmlnano/tree/master/lib/presets). You can choose either `ampSafe`, `max`, or `safe`.
 
 3. Create a JS-file inside `test/modules/` with some unit-tests.
 


### PR DESCRIPTION
There is no `the modules array` anymore. Modules are now loaded automatically according to `options` and `presets` since `0.2.0`.