### PR TITLE
Feat: remove "type=text/css" for link[rel=stylesheet]

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ Removes redundant attributes from tags if they contain default values:
 - `language="javascript"` and `type="text/javascript"` from `<script>`
 - `charset` from `<script>` if it's an external script
 - `media="all"` from `<style>` and `<link>`
+- `type="text/css"` from `<link rel="stylesheet">`
 
 ##### Options
 This module is disabled by default, change option to true to enable this module.

--- a/lib/modules/removeRedundantAttributes.es6
+++ b/lib/modules/removeRedundantAttributes.es6
@@ -28,7 +28,26 @@ const redundantAttributes = {
     },
 
     'link': {
-        'media': 'all'
+        'media': 'all',
+        'type': node => {
+            // https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet
+            let isRelStyleSheet = false;
+            let isTypeTextCSS = false;
+
+            if (node.attrs) {
+                for (const [attrName, attrValue] of Object.entries(node.attrs)) {
+                    if (attrName.toLowerCase() === 'rel' && attrValue === 'stylesheet') {
+                        isRelStyleSheet = true;
+                    }
+                    if (attrName.toLowerCase() === 'type' && attrValue === 'text/css') {
+                        isTypeTextCSS = true;
+                    }
+                }
+            }
+
+            // Only "text/css" is redudant for link[rel=stylesheet]. Otherwise "type" shouldn't be removed
+            return isRelStyleSheet && isTypeTextCSS;
+        }
     }
 };
 

--- a/test/modules/removeRedundantAttributes.js
+++ b/test/modules/removeRedundantAttributes.js
@@ -62,4 +62,20 @@ describe('removeRedundantAttributes', () => {
             options
         );
     });
+
+    it('should remove type="text/css" from link[rel=stylesheet]', () => {
+        return init(
+            '<link rel="stylesheet" type="text/css" href="style.css">',
+            '<link rel="stylesheet" href="style.css">',
+            options
+        );
+    });
+
+    it('shouldn\'t remove new type from link[rel=stylesheet]', () => {
+        return init(
+            '<link rel="stylesheet" type="text/example" href="style.css">',
+            '<link rel="stylesheet" type="text/example" href="style.css">',
+            options
+        );
+    });
 });


### PR DESCRIPTION
`type=text/css` is redudant for `link[rel=stylesheet]`. The PR introduces the feature to `removeRedundantAttributes` module.