### PR TITLE
Feat: removeAttributeQuotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,37 @@ Minified:
 <img src="foo.jpg" alt="">
 ```
 
+### removeAttributeQuotes
+Remove quotes around attributes when possible, see [HTML Standard - 12.1.2.3 Attributes - Unquoted attribute value syntax](https://html.spec.whatwg.org/multipage/syntax.html#attributes-2).
+
+##### Example
+Source:
+```html
+<div class="foo" title="hello world"></div>
+```
+
+Minified:
+```html
+<div class=foo title="hello world"></div>
+```
+
+##### Notice
+The feature is implemented by [posthtml-render's `quoteAllAttributes`](https://github.com/posthtml/posthtml-render#options), which is one of the PostHTML's option. So `removeAttributeQuotes` could be overriden by other PostHTML's plugins and PostHTML's configuration.
+
+For example:
+
+```js
+posthtml([
+    htmlnano({
+        removeAttributeQuotes: true
+    })
+]).process(html, {
+    quoteAllAttributes: true
+})
+```
+
+`removeAttributeQuotes` will not work because PostHTML's `quoteAllAttributes` takes the priority.
+
 ### removeUnusedCss
 
 Removes unused CSS inside `<style>` tags with either [uncss](https://github.com/uncss/uncss)

--- a/lib/modules/removeAttributeQuotes.es6
+++ b/lib/modules/removeAttributeQuotes.es6
@@ -1,0 +1,12 @@
+// Specification: https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+// See also: https://github.com/posthtml/posthtml-render/pull/30
+// See also: https://github.com/posthtml/htmlnano/issues/6#issuecomment-707105334
+
+/** Disable quoteAllAttributes while not overriding the configuration */
+export default function removeAttributeQuotes(tree) {
+    if (tree.options && typeof tree.options.quoteAllAttributes === 'undefined') {
+        tree.options.quoteAllAttributes = false;
+    }
+
+    return tree;
+}

--- a/lib/presets/max.es6
+++ b/lib/presets/max.es6
@@ -6,6 +6,7 @@ import safePreset from './safe';
 export default { ...safePreset,
     collapseWhitespace: 'all',
     removeComments: 'all',
+    removeAttributeQuotes: true,
     removeRedundantAttributes: true,
     removeUnusedCss: {},
     minifyCss: {

--- a/lib/presets/safe.es6
+++ b/lib/presets/safe.es6
@@ -26,6 +26,7 @@ export default {
     removeEmptyAttributes: true,
     removeRedundantAttributes: false,
     removeComments: 'safe',
+    removeAttributeQuotes: false,
     sortAttributesWithLists: true,
     minifyUrls: false,
 };

--- a/test/modules/removeAttributeQuotes.js
+++ b/test/modules/removeAttributeQuotes.js
@@ -1,0 +1,30 @@
+import { init } from '../htmlnano';
+import safePreset from '../../lib/presets/safe';
+
+import posthtml from 'posthtml';
+import htmlnano from '../..';
+import expect from 'expect';
+
+describe('removeAttributeQuotes', () => {
+    const options = { ...safePreset, removeAttributeQuotes: true };
+    const html = '<div class="foo" title="hello world"></div>';
+
+    it('default behavior', () => {
+        return init(
+            html,
+            '<div class=foo title="hello world"></div>',
+            options
+        );
+    });
+
+    it('shouldn\'t override exists options', () => {
+        return posthtml([
+            htmlnano(options, {})
+        ]).process(
+            html,
+            { quoteAllAttributes: true }
+        ).then((result) => {
+            expect(result.html).toBe(html);
+        });
+    });
+});


### PR DESCRIPTION
Closes #6 

Implement a module that will be able to access and modify `tree.options.quoteAllAttributes`.

Notice it is not safe to changing `tree.options` directly (although PostHTML Team doesn't think so). I have already discussed it with PostHTML Team (https://github.com/posthtml/posthtml/issues/335). There should be a better approach.