### PR TITLE
Refactor: trim more whitespaces for aggressive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,17 +202,13 @@ Collapses redundant white spaces (including new lines). It doesn’t affect whit
 
 ##### Options
 - `conservative` — collapses all redundant white spaces to 1 space (default)
-- `aggressive` — removes newlines and tabs, collapses remaining whitespaces to 1 space.
+- `aggressive` — collapses all whitespaces that are redundant and safe to remove
 - `all` — collapses all redundant white spaces
 
 ##### Side effects
-*aggressive*  
-`<i>hello</i>`<br />`<i>world</i>`
- after minification will be rendered as `helloworld`.
-To prevent this include at least one real space character between the tags.
 
 *all*  
-`<i>hello</i> <i>world</i>` after minification will be rendered as `helloworld`.
+`<i>hello</i> <i>world</i>` or `<i>hello</i><br><i>world</i>` after minification will be rendered as `helloworld`.
 To prevent that use either the default `conservative` option, or the `aggressive` option.
 
 ##### Example

--- a/lib/modules/collapseWhitespace.es6
+++ b/lib/modules/collapseWhitespace.es6
@@ -19,7 +19,6 @@ const noTrimWhitespacesInsideElements = new Set([
     'a', 'abbr', 'acronym', 'b', 'big', 'del', 'em', 'font', 'i', 'ins', 'kbd', 'mark', 'nobr', 'rp', 's', 'samp', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'time', 'tt', 'u', 'var'
 ]);
 
-const indentPattern = /[\f\n\r\t\v]{1,}/g;
 const whitespacePattern = /[\f\n\r\t\v ]{1,}/g;
 const onlyWhitespacePattern = /^[\f\n\r\t\v ]+$/;
 const NONE = '';
@@ -70,10 +69,6 @@ export default function collapseWhitespace(tree, options, collapseType, tag) {
 function collapseRedundantWhitespaces(text, collapseType, shouldTrim = false, currentTag, prevNodeTag, nextNodeTag) {
     if (!text || text.length === 0) {
         return NONE;
-    }
-
-    if (collapseType === 'aggressive') {
-        text = text.replace(indentPattern, SINGLE_SPACE);
     }
 
     text = text.replace(whitespacePattern, SINGLE_SPACE);

--- a/test/modules/collapseWhitespace.js
+++ b/test/modules/collapseWhitespace.js
@@ -5,9 +5,12 @@ import maxPreset from '../../lib/presets/max';
 
 describe('collapseWhitespace', () => {
     const html = ` <div>
-            <b> hello  world! </b><a>other link
-	</a>
-	  </div>  `;
+    <p>      Hello world	</p>
+    <pre>   <code>	posthtml    htmlnano     </code>	</pre>
+    <code>	posthtml    htmlnano     </code>
+            <b> hello  world! </b>  <a>other link
+    </a>
+	Example   </div>  `;
 
     const documentationHtml = `<div>
     hello  world!
@@ -24,7 +27,7 @@ describe('collapseWhitespace', () => {
     const topLevelTags = 'top-level tags (html, head, body)';
     const topLevelTagsHtml = ` <html>
                     <head>
-                        <title> Test </title>
+                        <title> Test   Test  </title>
                         <script> </script>
                     </head>
                     <body>
@@ -39,7 +42,7 @@ describe('collapseWhitespace', () => {
         it('should collapse redundant whitespaces', () => {
             return init(
                 html,
-                '<div><b>hello world!</b><a>other link</a></div>',
+                '<div><p>Hello world</p><pre>   <code>	posthtml    htmlnano     </code>	</pre><code>posthtml htmlnano</code><b>hello world!</b><a>other link</a>Example</div>',
                 options
             );
         });
@@ -56,7 +59,7 @@ describe('collapseWhitespace', () => {
         it('should collapse whitespaces between ' + topLevelTags, () => {
             return init(
                 topLevelTagsHtml,
-                '<html><head><title>Test</title><script> </script></head><body></body></html>',
+                '<html><head><title>Test Test</title><script> </script></head><body></body></html>',
                 options
             );
         });
@@ -79,7 +82,7 @@ describe('collapseWhitespace', () => {
         it('should collapse redundant whitespaces and eliminate indentation (tabs, newlines, etc)', () => {
             return init(
                 html,
-                '<div> <b> hello world! </b><a>other link</a> </div>',
+                '<div><p>Hello world</p><pre>   <code>	posthtml    htmlnano     </code>	</pre> <code>posthtml htmlnano</code> <b> hello world! </b> <a>other link </a> Example</div>',
                 options
             );
         });
@@ -88,7 +91,7 @@ describe('collapseWhitespace', () => {
             return init(
                 inviolateTagsHtml,
                 '<script> alert() </script><style>.foo  {}</style><pre> hello <b> , </b> </pre>' +
-                '<div> <!--  hello   world  --> </div><textarea> world! </textarea>',
+                '<div><!--  hello   world  --></div> <textarea> world! </textarea>',
                 options
             );
         });
@@ -96,7 +99,7 @@ describe('collapseWhitespace', () => {
         it('should collapse whitespaces between ' + topLevelTags, () => {
             return init(
                 topLevelTagsHtml,
-                '<html><head><title> Test </title><script> </script></head><body> </body></html>',
+                '<html><head><title>Test Test</title><script> </script></head><body></body></html>',
                 options
             );
         });
@@ -104,7 +107,7 @@ describe('collapseWhitespace', () => {
         it('renders the documentation example correctly', () => {
             return init(
                 documentationHtml,
-                '<div> hello world! <a href="#">answer</a> <style>div  { color: red; }  </style><main></main></div>',
+                '<div>hello world! <a href="#">answer</a> <style>div  { color: red; }  </style><main></main></div>',
                 options
             );
         });
@@ -119,7 +122,7 @@ describe('collapseWhitespace', () => {
         it('should collapse to 1 space', () => {
             return init(
                 html,
-                '<div> <b> hello world! </b><a>other link </a> </div>',
+                '<div> <p> Hello world </p> <pre>   <code>	posthtml    htmlnano     </code>	</pre> <code> posthtml htmlnano </code> <b> hello world! </b> <a>other link </a> Example </div>',
                 options
             );
         });
@@ -127,7 +130,7 @@ describe('collapseWhitespace', () => {
         it('should collapse whitespaces between ' + topLevelTags, () => {
             return init(
                 topLevelTagsHtml,
-                '<html><head><title> Test </title><script> </script></head><body> </body></html>',
+                '<html><head><title> Test Test </title><script> </script></head><body> </body></html>',
                 options
             );
         });


### PR DESCRIPTION
#103.

Removing more and less (explanation below) white spaces for `aggressive` mode, results in an even smaller size of outputs.

After the PR, it will be unlikely for `aggressive` mode to break the page.