### PR TITLE
Feat: collapse crossorigin attributes

### DIFF
--- a/lib/modules/collapseBooleanAttributes.es6
+++ b/lib/modules/collapseBooleanAttributes.es6
@@ -120,6 +120,17 @@ export default function collapseBooleanAttributes(tree, options, moduleOptions) 
             if (moduleOptions.amphtml && node.attrs[attrName] === '' && amphtmlBooleanAttributes.has(attrName)) {
                 node.attrs[attrName] = true;
             }
+
+            // collapse crossorigin attributes
+            // Specification: https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes
+            if (
+                attrName.toLowerCase() === 'crossorigin' && (
+                    node.attrs[attrName] === 'anonymous' ||
+                    node.attrs[attrName] === ''
+                )
+            ) {
+                node.attrs[attrName] = true;
+            }
         }
 
         return node;

--- a/test/modules/collapseBooleanAttributes.js
+++ b/test/modules/collapseBooleanAttributes.js
@@ -61,4 +61,28 @@ describe('collapseBooleanAttributes', () => {
             options
         );
     });
+
+    it('should collapse crossorigin=anonymous attribute', () => {
+        return init(
+            '<script src="example-framework.js" crossorigin="anonymous"></script>',
+            '<script src="example-framework.js" crossorigin></script>',
+            options
+        );
+    });
+
+    it('should collapse crossorigin="" attribute', () => {
+        return init(
+            '<script src="example-framework.js" crossorigin=""></script>',
+            '<script src="example-framework.js" crossorigin></script>',
+            options
+        );
+    });
+
+    it('should not collapse crossorigin="use-credentials" attribute', () => {
+        return init(
+            '<script src="example-framework.js" crossorigin="use-credentials"></script>',
+            '<script src="example-framework.js" crossorigin="use-credentials"></script>',
+            options
+        );
+    });
 });


### PR DESCRIPTION
Add back collapse `crossorigin` attributes again.

Instead of treat `crossorigin` as a Boolean attribute, now `crossorigin` will only be collapsed if `crossorigin='anonymous'` or `crossorigin=''`. So `crossorigin='use-credentials'` will not be affected.

cc @Oloompa @fstanis 

Ref: #78 #79