### PR TITLE
Feat: exclude excerpt comment

### DIFF
--- a/lib/modules/removeComments.es6
+++ b/lib/modules/removeComments.es6
@@ -1,5 +1,6 @@
 import { isComment, isConditionalComment } from '../helpers';
 
+const MATCH_EXCERPT_REGEXP = /<!-- ?more ?-->/i;
 
 /** Removes HTML comments */
 export default function removeComments(tree, options, removeType) {
@@ -48,6 +49,15 @@ function isCommentToRemove(text, removeType) {
 
         // https://en.wikipedia.org/wiki/Conditional_comment
         if (isConditionalComment(text)) {
+            return false;
+        }
+
+        // Hexo: https://hexo.io/docs/tag-plugins#Post-Excerpt
+        // Hugo: https://gohugo.io/content-management/summaries/#manual-summary-splitting
+        // WordPress: https://wordpress.com/support/wordpress-editor/blocks/more-block/2/
+        // Jekyll: https://jekyllrb.com/docs/posts/#post-excerpts
+        const isCMSExcerptComment = MATCH_EXCERPT_REGEXP.test(text);
+        if (isCMSExcerptComment) {
             return false;
         }
     }

--- a/test/modules/removeComments.js
+++ b/test/modules/removeComments.js
@@ -40,6 +40,14 @@ describe('removeComments', () => {
                 options
             );
         });
+
+        it('should not remove excerpt comments <!-- more -->', () => {
+            return init(
+                'Lorem ipsum dolor sit amet <!-- more --> consectetur adipiscing elit',
+                'Lorem ipsum dolor sit amet <!-- more --> consectetur adipiscing elit',
+                options
+            );
+        });
     });
 
 
@@ -68,6 +76,14 @@ describe('removeComments', () => {
             return init(
                 '<!--[if IE 8]><link href="ie8only.css" rel="stylesheet"><![endif]-->',
                 '',
+                options
+            );
+        });
+
+        it('should remove excerpt comments <!-- more -->', () => {
+            return init(
+                'Lorem ipsum dolor sit amet <!-- more --> consectetur adipiscing elit',
+                'Lorem ipsum dolor sit amet  consectetur adipiscing elit',
                 options
             );
         });


### PR DESCRIPTION
Exclude excerpt comment for common CMS:

- Hexo: https://hexo.io/docs/tag-plugins#Post-Excerpt
- Hugo: https://gohugo.io/content-management/summaries/#manual-summary-splitting
- WordPress: https://wordpress.com/support/wordpress-editor/blocks/more-block/2/
- Jekyll: https://jekyllrb.com/docs/posts/#post-excerpts