### PR TITLE
Feat: removeOptionalTags

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,6 +773,31 @@ Minified:
 <a href="../bar">bar</a>
 ```
 
+## removeOptionalTags
+Remove certain tags that can be omitted, see [HTML Standard - 13.1.2.4 Optional tags](https://html.spec.whatwg.org/multipage/syntax.html#optional-tags).
+
+##### Example
+
+Source:
+
+```html
+<html><head><title>Title</title></head><body><p>Hi</p></body></html>
+```
+
+Minified:
+
+```html
+<title>Title</title><p>Hi</p>
+```
+##### Notice
+Due to [the limitation of PostHTML](https://github.com/posthtml/htmlnano/issues/99), htmlnano can't remove only the start tag or the end tag of an element. Currently, htmlnano only supports removing the following optional tags, as htmlnano can remove their start tag and end tag at the same time:
+
+- `html`
+- `head`
+- `body`
+- `colgroup`
+- `tbody`
+
 ## Contribute
 Since the minifier is modular, it's very easy to add new modules:
 

--- a/lib/modules/removeOptionalTags.es6
+++ b/lib/modules/removeOptionalTags.es6
@@ -1,0 +1,227 @@
+import { isComment } from '../helpers';
+
+const startWithWhitespacePattern = /^[\f\n\r\t\v ]+/;
+
+const bodyStartTagCantBeOmittedWithFirstChildTags = new Set(['meta', 'link', 'script', 'style']);
+const tbodyStartTagCantBeOmittedWithPrecededTags = new Set(['tbody', 'thead', 'tfoot']);
+const tbodyEndTagCantBeOmittedWithFollowedTags = new Set(['tbody', 'tfoot']);
+
+function isEmptyTextNode(node) {
+    if (typeof node === 'string' && node.trim() === '') {
+        return true;
+    }
+
+    return false;
+}
+
+function isEmptyNode(node) {
+    if (!node.content) {
+        return true;
+    }
+
+    if (node.content.length) {
+        return !node.content.filter(n => typeof n === 'string' && isEmptyTextNode(n) ? false : true).length;
+    }
+
+    return true;
+}
+
+function getFirstChildTag(node, nonEmpty = true) {
+    if (node.content && node.content.length) {
+        if (nonEmpty) {
+            for (const childNode of node.content) {
+                if (childNode.tag) return childNode;
+                if (typeof childNode === 'string' && !isEmptyTextNode(childNode)) return childNode;
+            }
+        } else {
+            return node.content[0] || null;
+        }
+    }
+
+    return null;
+}
+
+function getPrevNode(tree, currentNodeIndex, nonEmpty = false) {
+    if (nonEmpty) {
+        for (let i = currentNodeIndex - 1; i >= 0; i--) {
+            const node = tree[i];
+            if (node.tag) return node;
+            if (typeof node === 'string' && !isEmptyTextNode(node)) return node;
+        }
+    } else {
+        return tree[currentNodeIndex - 1] || null;
+    }
+
+    return null;
+}
+
+function getNextNode(tree, currentNodeIndex, nonEmpty = false) {
+    if (nonEmpty) {
+        for (let i = currentNodeIndex + 1; i < tree.length; i++) {
+            const node = tree[i];
+            if (node.tag) return node;
+            if (typeof node === 'string' && !isEmptyTextNode(node)) return node;
+        }
+    } else {
+        return tree[currentNodeIndex + 1] || null;
+    }
+
+    return null;
+}
+
+// Specification https://html.spec.whatwg.org/multipage/syntax.html#optional-tags
+/** Remove optional tag in the DOM */
+export default function removeOptionalTags(tree) {
+    tree.forEach((node, index) => {
+        if (!node.tag) return node;
+
+        if (node.attrs && Object.keys(node.attrs).length) return node;
+
+        // const prevNode = getPrevNode(tree, index);
+        const prevNonEmptyNode = getPrevNode(tree, index, true);
+        const nextNode = getNextNode(tree, index);
+        const nextNonEmptyNode = getNextNode(tree, index, true);
+        const firstChildNode = getFirstChildTag(node, false);
+        const firstNonEmptyChildNode = getFirstChildTag(node);
+
+        /**
+         * An "html" element's start tag may be omitted if the first thing inside the "html" element is not a comment.
+         * An "html" element's end tag may be omitted if the "html" element is not IMMEDIATELY followed by a comment.
+         */
+        if (node.tag === 'html') {
+            let isHtmlStartTagCanBeOmitted = true;
+            let isHtmlEndTagCanBeOmitted = true;
+
+            if (typeof firstNonEmptyChildNode === 'string' && isComment(firstNonEmptyChildNode)) {
+                isHtmlStartTagCanBeOmitted = false;
+            }
+
+            if (typeof nextNonEmptyNode === 'string' && isComment(nextNonEmptyNode)) {
+                isHtmlEndTagCanBeOmitted = false;
+            }
+
+            if (isHtmlStartTagCanBeOmitted && isHtmlEndTagCanBeOmitted) {
+                node.tag = false;
+            }
+        }
+
+        /**
+         * A "head" element's start tag may be omitted if the element is empty, or if the first thing inside the "head" element is an element.
+         * A "head" element's end tag may be omitted if the "head" element is not IMMEDIATELY followed by ASCII whitespace or a comment.
+         */
+        if (node.tag === 'head') {
+            let isHeadStartTagCanBeOmitted = false;
+            let isHeadEndTagCanBeOmitted = true;
+
+            if (
+                isEmptyNode(node) ||
+                firstNonEmptyChildNode && firstNonEmptyChildNode.tag
+            ) {
+                isHeadStartTagCanBeOmitted = true;
+            }
+
+            if (
+                (nextNode && typeof nextNode === 'string' && startWithWhitespacePattern.test(nextNode)) ||
+                (nextNonEmptyNode && typeof nextNonEmptyNode === 'string' && isComment(nextNode))
+            ) {
+                isHeadEndTagCanBeOmitted = false;
+            }
+
+            if (isHeadStartTagCanBeOmitted && isHeadEndTagCanBeOmitted) {
+                node.tag = false;
+            }
+        }
+
+
+        /**
+         * A "body" element's start tag may be omitted if the element is empty, or if the first thing inside the "body" element is not ASCII whitespace or a comment, except if the first thing inside the "body" element is a "meta", "link", "script", "style", or "template" element.
+         * A "body" element's end tag may be omitted if the "body" element is not IMMEDIATELY followed by a comment.
+         */
+        if (node.tag === 'body') {
+            let isBodyStartTagCanBeOmitted = true;
+            let isBodyEndTagCanBeOmitted = true;
+
+            if (
+                (typeof firstChildNode === 'string' && startWithWhitespacePattern.test(firstChildNode)) ||
+                (typeof firstNonEmptyChildNode === 'string' && isComment(firstNonEmptyChildNode))
+            ) {
+                isBodyStartTagCanBeOmitted = false;
+            }
+
+            if (firstNonEmptyChildNode && firstNonEmptyChildNode.tag && bodyStartTagCantBeOmittedWithFirstChildTags.has(firstNonEmptyChildNode.tag)) {
+                isBodyStartTagCanBeOmitted = false;
+            }
+
+            if (nextNode && typeof nextNode === 'string' && isComment(nextNode)) {
+                isBodyEndTagCanBeOmitted = false;
+            }
+
+            if (isBodyStartTagCanBeOmitted && isBodyEndTagCanBeOmitted) {
+                node.tag = false;
+            }
+        }
+
+        /**
+         * A "colgroup" element's start tag may be omitted if the first thing inside the "colgroup" element is a "col" element, and if the element is not IMMEDIATELY preceded by another "colgroup" element. It can't be omitted if the element is empty.
+         * A "colgroup" element's end tag may be omitted if the "colgroup" element is not IMMEDIATELY followed by ASCII whitespace or a comment.
+         */
+        if (node.tag === 'colgroup') {
+            let isColgroupStartTagCanBeOmitted = false;
+            let isColgroupEndTagCanBeOmitted = true;
+
+            if (firstNonEmptyChildNode && firstNonEmptyChildNode.tag && firstNonEmptyChildNode.tag === 'col') {
+                isColgroupStartTagCanBeOmitted = true;
+            }
+
+            if (prevNonEmptyNode && prevNonEmptyNode.tag && prevNonEmptyNode.tag === 'colgroup') {
+                isColgroupStartTagCanBeOmitted = false;
+            }
+
+            if (
+                (nextNode && typeof nextNode === 'string' && startWithWhitespacePattern.test(nextNode)) ||
+                (nextNonEmptyNode && typeof nextNonEmptyNode === 'string' && isComment(nextNonEmptyNode))
+            ) {
+                isColgroupEndTagCanBeOmitted = false;
+            }
+
+            if (isColgroupStartTagCanBeOmitted && isColgroupEndTagCanBeOmitted) {
+                node.tag = false;
+            }
+        }
+
+        /**
+         * A "tbody" element's start tag may be omitted if the first thing inside the "tbody" element is a "tr" element, and if the element is not immediately preceded by another "tbody", "thead" or "tfoot" element. It can't be omitted if the element is empty.
+         * A "tbody" element's end tag may be omitted if the "tbody" element is not IMMEDIATELY followed by a "tbody" or "tfoot" element.
+         */
+        if (node.tag === 'tbody') {
+            let isTbodyStartTagCanBeOmitted = false;
+            let isTbodyEndTagCanBeOmitted = true;
+
+            if (firstNonEmptyChildNode && firstNonEmptyChildNode.tag && firstNonEmptyChildNode.tag === 'tr') {
+                isTbodyStartTagCanBeOmitted = true;
+            }
+
+            if (prevNonEmptyNode && prevNonEmptyNode.tag && tbodyStartTagCantBeOmittedWithPrecededTags.has(prevNonEmptyNode.tag)) {
+                isTbodyStartTagCanBeOmitted = false;
+            }
+
+            if (nextNonEmptyNode && nextNonEmptyNode.tag && tbodyEndTagCantBeOmittedWithFollowedTags.has(nextNonEmptyNode.tag)) {
+                isTbodyEndTagCanBeOmitted = false;
+            }
+
+            if (isTbodyStartTagCanBeOmitted && isTbodyEndTagCanBeOmitted) {
+                node.tag = false;
+            }
+        }
+
+        if (node.content && node.content.length) {
+            removeOptionalTags(node.content);
+        }
+
+        return node;
+    });
+
+    return tree;
+}
+
+

--- a/lib/presets/max.es6
+++ b/lib/presets/max.es6
@@ -13,4 +13,5 @@ export default { ...safePreset,
         preset: 'default',
     },
     minifySvg: {},
+    removeOptionalTags: true,
 };

--- a/lib/presets/safe.es6
+++ b/lib/presets/safe.es6
@@ -29,4 +29,5 @@ export default {
     removeAttributeQuotes: false,
     sortAttributesWithLists: true,
     minifyUrls: false,
+    removeOptionalTags: false,
 };

--- a/test/modules/removeOptionalTags.js
+++ b/test/modules/removeOptionalTags.js
@@ -1,0 +1,333 @@
+import { init } from '../htmlnano';
+
+describe('removeOptionalTags', () => {
+    const options = {
+        removeOptionalTags: true,
+    };
+
+    it('shouldn\'t omit optional tag if has attributes', () => {
+        const input = `
+        <html lang="en">
+            <p>Welcome to this example.</p>
+        </html>`;
+
+        return init(input, input, options);
+    });
+
+    it('document example', () => {
+        const input = '<html><head><title>Title</title></head><body><p>Hi</p></body></html>';
+        const expected = '<title>Title</title><p>Hi</p>';
+
+        return init(input, expected, options);
+    });
+
+    context('omit optional <html>', () => {
+        it('default', () => {
+            const input = `
+            <html>
+                <p>Welcome to this example.</p>
+            </html>
+            `;
+
+            const expected = `
+            
+                <p>Welcome to this example.</p>
+            
+            `;
+
+            return init(input, expected, options);
+        });
+
+        it('first thing inside <html> is a comment', () => {
+            const input = `
+            <html>
+                <!-- where is this comment in the DOM? -->
+            </html>`;
+
+            return init(input, input, options);
+        });
+
+        it('<html> is not immediately followed by a comment', () => {
+            const input = `
+            <html>
+                <p>Welcome to this example.</p>
+            </html><!-- where is this comment in the DOM? -->`;
+
+            return init(input, input, options);
+        });
+    });
+
+    context('omit optional <head>', () => {
+        it('<head> has elements', () => {
+            const input = '<head><title>Title</title>';
+            const expected = '<title>Title</title>';
+
+            return init(input, expected, options);
+        });
+
+        it('<head> surrouned by whitespaces', () => {
+            const input = `
+            <!DOCTYPE HTML>
+            <html>
+                <!-- prevent <html> being removed -->
+                <head>
+                    <title>Hello</title>
+                </head>
+            </html>`;
+
+            return init(input, input, options);
+        });
+
+        it('empty <head>', () => {
+            const input = `
+            <!DOCTYPE HTML>
+            <html>
+                <!-- prevent <html> being removed -->
+                <head>
+    
+                </head></html>`;
+
+            const expected = `
+            <!DOCTYPE HTML>
+            <html>
+                <!-- prevent <html> being removed -->
+                
+    
+                </html>`;
+
+            return init(input, expected, options);
+        });
+
+        it('the first node inside <head> element is text', () => {
+            const input = `
+            <!DOCTYPE HTML>
+            <html><!-- prevent <html> being removed --><head>Example</head></html>`;
+
+            return init(input, input, options);
+        });
+
+        it('<head> is followed by whitespaces', () => {
+            const input = `
+            <!DOCTYPE HTML>
+            <html><!-- prevent <html> being removed --><head></head>
+            </html>`;
+
+            return init(input, input, options);
+        });
+
+        it('<head> is followed by comment', () => {
+            const input = `
+            <!DOCTYPE HTML>
+            <html><!-- prevent <html> being removed --><head></head><!-- prevent <html> being removed -->
+            </html>`;
+
+            return init(input, input, options);
+        });
+    });
+
+    context('omit optional <body>', () => {
+        it('default', () => {
+            const input = `
+            <body>
+                <p>htmlnano</p>
+            </body>
+            `;
+
+            // There is whitespaces after <body> and before </body>, thus <body> can't be ommited
+            return init(input, input, options);
+        });
+
+        it('no white spaces nearby', () => {
+            const input = '<body><p>htmlnano</p></body>';
+            const expected = '<p>htmlnano</p>';
+
+            return init(input, expected, options);
+        });
+
+        it('empty <body>', () => {
+            const input = '<body></body>';
+            const expected = '';
+
+            return init(input, expected, options);
+        });
+    });
+
+    it('html spec example 1', () => {
+        const input = `
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <title>Hello</title>
+    </head>
+    <body>
+        <p>Welcome to this example.</p>
+    </body>
+</html>`;
+        // </body> just can't be reomved simply because posthtml can't do this.
+        // See https://github.com/posthtml/htmlnano/issues/99
+        const expected = `
+<!DOCTYPE HTML>
+
+    <head>
+        <title>Hello</title>
+    </head>
+    <body>
+        <p>Welcome to this example.</p>
+    </body>
+`;
+
+        return init(input, expected, options);
+    });
+
+    it('html spec example 2', () => {
+        const input = '<!DOCTYPE HTML><html><head><title>Hello</title></head><body><p>Welcome to this example.</p></body></html>';
+        const expected = '<!DOCTYPE HTML><title>Hello</title><p>Welcome to this example.</p>';
+
+        return init(input, expected, options);
+    });
+
+    context('omit optional <colgroup>', () => {
+        it('default', () => {
+            const input = '<colgroup><col><col><col></colgroup>';
+            const expected = '<col><col><col>';
+
+            return init(input, expected, options);
+        });
+
+        it('empty <colgroup>', () => {
+            const input = '<colgroup></colgroup>';
+
+            return init(input, input, options);
+        });
+
+        it('first child node is not <col>', () => {
+            const input = '<colgroup><div></div><col><col></colgroup>';
+
+            return init(input, input, options);
+        });
+
+        it('<colgroup> followed by comment', () => {
+            const input = '<colgroup><div></div><col><col></colgroup><!-- comment -->';
+
+            return init(input, input, options);
+        });
+
+        it('<colgroup> followed by space', () => {
+            const input = '<colgroup><div></div><col><col></colgroup> ';
+
+            return init(input, input, options);
+        });
+    });
+
+    context('omit optional <tbody>', () => {
+        it('omit <tbody>', () => {
+            const input = '<table><tbody><tr></tr></tbody></table>';
+            const expected = '<table><tr></tr></table>';
+
+            return init(input, expected, options);
+        });
+
+        it('<tbody> followed by another <tbody>', () => {
+            const input = '<table><tbody><tr></tr></tbody><tbody><tr></tr></tbody></table>';
+
+            return init(input, input, options);
+        });
+
+        it('<tbody> followed by <tfoot>', () => {
+            const input = '<table><tbody><tr></tr></tbody><tfoot></tfoot></table>';
+
+            return init(input, input, options);
+        });
+
+        it('empty <tbody>', () => {
+            const input = '<tbody></tbody>';
+
+            return init(input, input, options);
+        });
+    });
+
+    it('html spec example 3', () => {
+        const input = `
+<table>
+ <caption>37547 TEE Electric Powered Rail Car Train Functions (Abbreviated)</caption>
+ <colgroup><col><col><col></colgroup>
+ <thead>
+  <tr>
+   <th>Function</th>
+   <th>Control Unit</th>
+   <th>Central Station</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>Headlights</td>
+   <td>✔</td>
+   <td>✔</td>
+  </tr>
+  <tr>
+   <td>Interior Lights</td>
+   <td>✔</td>
+   <td>✔</td>
+  </tr>
+  <tr>
+   <td>Electric locomotive operating sounds</td>
+   <td>✔</td>
+   <td>✔</td>
+  </tr>
+  <tr>
+   <td>Engineer's cab lighting</td>
+   <td></td>
+   <td>✔</td>
+  </tr>
+  <tr>
+   <td>Station Announcements - Swiss</td>
+   <td></td>
+   <td>✔</td>
+  </tr>
+ </tbody>
+</table>`;
+        // </caption>, </thead>, </th>, </td> and </tr> just can't be reomved simply because posthtml can't do this.
+        // See https://github.com/posthtml/htmlnano/issues/99
+        const expected = `
+<table>
+ <caption>37547 TEE Electric Powered Rail Car Train Functions (Abbreviated)</caption>
+ <colgroup><col><col><col></colgroup>
+ <thead>
+  <tr>
+   <th>Function</th>
+   <th>Control Unit</th>
+   <th>Central Station</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>Headlights</td>
+   <td>✔</td>
+   <td>✔</td>
+  </tr>
+  <tr>
+   <td>Interior Lights</td>
+   <td>✔</td>
+   <td>✔</td>
+  </tr>
+  <tr>
+   <td>Electric locomotive operating sounds</td>
+   <td>✔</td>
+   <td>✔</td>
+  </tr>
+  <tr>
+   <td>Engineer's cab lighting</td>
+   <td></td>
+   <td>✔</td>
+  </tr>
+  <tr>
+   <td>Station Announcements - Swiss</td>
+   <td></td>
+   <td>✔</td>
+  </tr>
+ </tbody>
+</table>`;
+
+        return init(input, expected, options);
+    });
+});


### PR DESCRIPTION
#29.

Due to the limitation of PostHTML (#99), only `html`, `head`, `body`, `colgroup`, `tbody` are supported, since only their start tag (opening tag) & end tag (closing tag) can be omitted at the same time.