### PR TITLE
Feat: support sort list-like attribute values by frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,15 @@ Sort values in list-like attributes (`class`, `rel`, `ping`).
 
 The module won't impact the plain-text size of the output. However it will improve the compression ratio of gzip/brotli used in HTTP compression.
 
+##### Options
+
+- `alphabetical`: Default option. Sort attribute values in alphabetical order.
+- `frequency`: Sort attribute values by frequency.
+
 ##### Example
+
+**alphabetical**
+
 Source:
 ```html
 <div class="foo baz bar">click</div>
@@ -694,6 +702,18 @@ Source:
 Processed:
 ```html
 <div class="bar baz foo">click</div>
+```
+
+**frequency**
+
+Source:
+```html
+<div class="foo baz bar"></div><div class="bar foo"></div>
+```
+
+Processed:
+```html
+<div class="foo bar baz"></div><div class="foo bar"></div>
 ```
 
 ### minifyUrls

--- a/lib/modules/sortAttributesWithLists.es6
+++ b/lib/modules/sortAttributesWithLists.es6
@@ -1,25 +1,135 @@
+// class, rel, ping
 import { attributesWithLists } from './collapseAttributeWhitespace';
 
+const validOptions = new Set(['frequency', 'alphabetical']);
+const processModuleOptions = options => {
+    if (options === true) return 'alphabetical';
+
+    return validOptions.has(options) ? options : 'alphabetical';
+};
+
+class AttributeTokenChain {
+    constructor() {
+        this.freqData = new Map(); // <attrValue, frequency>[]
+    }
+
+    addFromNodeAttrsArray(attrValuesArray) {
+        attrValuesArray.forEach(attrValue => {
+            if (this.freqData.has(attrValue)) {
+                this.freqData.set(attrValue, this.freqData.get(attrValue) + 1);
+            } else {
+                this.freqData.set(attrValue, 1);
+            }
+        });
+    }
+
+    createSortOrder() {
+        let _sortOrder = [];
+        for (const item of this.freqData.entries()) {
+            _sortOrder.push(item);
+        }
+
+        this.sortOrder = _sortOrder.sort((a, b) => b[1] - a[1]).map(i => i[0]);
+    }
+
+    sortFromNodeAttrsArray(attrValuesArray) {
+        const resultArray = [];
+
+        if (!this.sortOrder) {
+            this.createSortOrder();
+        }
+
+        this.sortOrder.forEach(k => {
+            if (attrValuesArray.includes(k)) {
+                resultArray.push(k);
+            }
+        });
+
+        return resultArray;
+    }
+}
+
 /** Sort values inside list-like attributes (e.g. class, rel) */
-export default function collapseAttributeWhitespace(tree) {
+export default function collapseAttributeWhitespace(tree, options, moduleOptions) {
+    const sortType = processModuleOptions(moduleOptions);
+
+    if (sortType === 'alphabetical') {
+        return sortAttributesWithListsInAlphabeticalOrder(tree);
+    }
+
+    if (sortType === 'frequency') {
+        return sortAttributesWithListsByFrequency(tree);
+    }
+
+    return tree;
+}
+
+function sortAttributesWithListsInAlphabeticalOrder(tree) {
     tree.walk(node => {
-        if (! node.attrs) {
+        if (!node.attrs) {
             return node;
         }
 
         Object.keys(node.attrs).forEach(attrName => {
             const attrNameLower = attrName.toLowerCase();
-            if (! attributesWithLists.has(attrNameLower)) {
+            if (!attributesWithLists.has(attrNameLower)) {
                 return;
             }
 
             const attrValues = node.attrs[attrName].split(/\s/);
 
-            node.attrs[attrName] = attrValues.sort().join(' ');
+            node.attrs[attrName] = attrValues.sort((a, b) => {
+                return typeof a.localeCompare === 'function' ? a.localeCompare(b) : a - b;
+            }).join(' ');
         });
 
         return node;
     });
 
     return tree;
+}
+
+function sortAttributesWithListsByFrequency(tree) {
+    const tokenChainObj = {}; // <attrNameLower: AttributeTokenChain>[]
+
+    // Traverse through tree to get frequency
+    tree.walk(node => {
+        if (!node.attrs) {
+            return node;
+        }
+
+        Object.entries(node.attrs).forEach(([attrName, attrValues]) => {
+            const attrNameLower = attrName.toLowerCase();
+
+            if (!attributesWithLists.has(attrNameLower)) {
+                return;
+            }
+
+            tokenChainObj[attrNameLower] = tokenChainObj[attrNameLower] || new AttributeTokenChain();
+            tokenChainObj[attrNameLower].addFromNodeAttrsArray(attrValues.split(/\s/));
+        });
+
+        return node;
+    });
+
+    // Traverse through tree again, this time sort the attribute values
+    tree.walk(node => {
+        if (!node.attrs) {
+            return node;
+        }
+
+        Object.entries(node.attrs).forEach(([attrName, attrValues]) => {
+            const attrNameLower = attrName.toLowerCase();
+
+            if (!attributesWithLists.has(attrNameLower)) {
+                return;
+            }
+
+            if (tokenChainObj[attrNameLower]) {
+                node.attrs[attrName] = tokenChainObj[attrNameLower].sortFromNodeAttrsArray(attrValues.split(/\s/)).join(' ');
+            }
+        });
+
+        return node;
+    });
 }

--- a/lib/modules/sortAttributesWithLists.es6
+++ b/lib/modules/sortAttributesWithLists.es6
@@ -5,7 +5,7 @@ const validOptions = new Set(['frequency', 'alphabetical']);
 const processModuleOptions = options => {
     if (options === true) return 'alphabetical';
 
-    return validOptions.has(options) ? options : 'alphabetical';
+    return validOptions.has(options) ? options : false;
 };
 
 class AttributeTokenChain {
@@ -61,6 +61,7 @@ export default function collapseAttributeWhitespace(tree, options, moduleOptions
         return sortAttributesWithListsByFrequency(tree);
     }
 
+    // Invalid configuration
     return tree;
 }
 

--- a/lib/presets/safe.es6
+++ b/lib/presets/safe.es6
@@ -27,7 +27,7 @@ export default {
     removeRedundantAttributes: false,
     removeComments: 'safe',
     removeAttributeQuotes: false,
-    sortAttributesWithLists: true,
+    sortAttributesWithLists: 'alphabetical',
     minifyUrls: false,
     removeOptionalTags: false,
 };

--- a/test/modules/sortAttributesWithLists.js
+++ b/test/modules/sortAttributesWithLists.js
@@ -13,8 +13,8 @@ describe('sortAttributesWithLists', () => {
 
     it('frequency', () => {
         return init(
-            '<a class="foo baz bar">click</a><a class="foo bar">click</a>',
-            '<a class="foo bar baz">click</a><a class="foo bar">click</a>',
+            '<div class="foo baz bar"></div><div class="bar foo"></div>',
+            '<div class="foo bar baz"></div><div class="foo bar"></div>',
             {
                 sortAttributesWithLists: 'frequency',
             }

--- a/test/modules/sortAttributesWithLists.js
+++ b/test/modules/sortAttributesWithLists.js
@@ -1,16 +1,33 @@
 import { init } from '../htmlnano';
-import safePreset from '../../lib/presets/safe';
 
 describe('sortAttributesWithLists', () => {
-    const options = {
-        sortAttributesWithLists: safePreset.sortAttributesWithLists,
-    };
-
-    it('it sort values from list-like attributes', () => {
+    it('alphabetical', () => {
         return init(
-            '<a class="foo baz bar">click</a>',
-            '<a class="bar baz foo">click</a>',
-            options
+            '<a class="foo baz bar">click</a><a class="foo bar">click</a>',
+            '<a class="bar baz foo">click</a><a class="bar foo">click</a>',
+            {
+                sortAttributesWithLists: 'alphabetical',
+            }
+        );
+    });
+
+    it('frequency', () => {
+        return init(
+            '<a class="foo baz bar">click</a><a class="foo bar">click</a>',
+            '<a class="foo bar baz">click</a><a class="foo bar">click</a>',
+            {
+                sortAttributesWithLists: 'frequency',
+            }
+        );
+    });
+
+    it('true (alphabetical)', () => {
+        return init(
+            '<a class="foo baz bar">click</a><a class="foo bar">click</a>',
+            '<a class="bar baz foo">click</a><a class="bar foo">click</a>',
+            {
+                sortAttributesWithLists: true,
+            }
         );
     });
 });

--- a/test/modules/sortAttributesWithLists.js
+++ b/test/modules/sortAttributesWithLists.js
@@ -30,4 +30,15 @@ describe('sortAttributesWithLists', () => {
             }
         );
     });
+
+    it('invalid configuration', () => {
+        const input = '<a class="foo baz bar">click</a><a class="foo bar">click</a>';
+        return init(
+            input,
+            input,
+            {
+                sortAttributesWithLists: 100,
+            }
+        );
+    });
 });


### PR DESCRIPTION
#86.

Support sort list-like attribute values by frequency.

Now `sortAttributesWithLists` configuration accept following values:

- `alphabetical`
- `frequency`

Old configuration `true` will be considered as `alphabetical`, thus no breaking changes being introduced.