### PR TITLE
Feat: strip more spaces for collapseWhitespace

### DIFF
--- a/lib/modules/collapseWhitespace.es6
+++ b/lib/modules/collapseWhitespace.es6
@@ -76,6 +76,17 @@ function collapseRedundantWhitespaces(text, collapseType, shouldTrim = false, cu
     if (shouldTrim) {
         if (collapseType === 'aggressive') {
             if (onlyWhitespacePattern.test(text)) {
+                if (!noTrimWhitespacesArroundElements.has(currentTag)) {
+                    // Remove very first and very end spaces inside text node
+                    if (typeof prevNodeTag === 'undefined') {
+                        text = text.trimStart();
+                    }
+
+                    if (typeof nextNodeTag === 'undefined') {
+                        text = text.trimEnd();
+                    }
+                }
+
                 // "text" only contains whitespaces. Only trim when both prevNodeTag & nextNodeTag are not "noTrimWhitespacesArroundElement"
                 // Otherwise the required ONE whitespace will be trimmed
                 if (

--- a/test/modules/collapseWhitespace.js
+++ b/test/modules/collapseWhitespace.js
@@ -20,6 +20,12 @@ describe('collapseWhitespace', () => {
         </span>
     </span>
 </div>
+<div>
+    lorem
+    <span>
+        opren
+    </span>
+</div>
 `;
 
     const documentationHtml = `<div>
@@ -77,7 +83,7 @@ describe('collapseWhitespace', () => {
         it('should collapse whitespaces inside text node', () => {
             return init(
                 spaceInsideTextNodeHtml,
-                '<div><span>lorem<span>iorem</span></span></div>',
+                '<div><span>lorem<span>iorem</span></span></div><div>lorem<span>opren</span></div>',
                 options
             );
         });
@@ -125,7 +131,7 @@ describe('collapseWhitespace', () => {
         it('should collapse whitespaces inside text node', () => {
             return init(
                 spaceInsideTextNodeHtml,
-                '<div><span> lorem <span> iorem </span> </span></div>',
+                '<div><span> lorem <span> iorem </span> </span></div><div>lorem <span> opren </span></div>',
                 options
             );
         });
@@ -134,24 +140,6 @@ describe('collapseWhitespace', () => {
             return init(
                 documentationHtml,
                 '<div>hello world! <a href="#">answer</a> <style>div  { color: red; }  </style><main></main></div>',
-                options
-            );
-        });
-
-        it('test', () => {
-            const html = `
-<div class="post-meta">
-            <time datetime="2020-10-13T09:25:00.000Z">2020-10-13</time>
-                    <span class="dot">
-                     <span> </span>
-                    </span>
-        </div>`;
-
-            const expected = '<div class="post-meta"><time datetime="2020-10-13T09:25:00.000Z">2020-10-13</time> <span class="dot"> <span> </span> </span></div>';
-
-            return init(
-                html,
-                expected,
                 options
             );
         });
@@ -191,7 +179,7 @@ describe('collapseWhitespace', () => {
         it('should collapse whitespaces inside text node', () => {
             return init(
                 spaceInsideTextNodeHtml,
-                '<div> <span> lorem <span> iorem </span> </span> </div>',
+                '<div> <span> lorem <span> iorem </span> </span> </div><div> lorem <span> opren </span> </div>',
                 options
             );
         });

--- a/test/modules/collapseWhitespace.js
+++ b/test/modules/collapseWhitespace.js
@@ -10,7 +10,17 @@ describe('collapseWhitespace', () => {
     <code>	posthtml    htmlnano     </code>
             <b> hello  world! </b>  <a>other link
     </a>
-	Example   </div>  `;
+    Example   </div>  `;
+
+    const spaceInsideTextNodeHtml = `
+<div>
+    <span> lorem
+        <span>
+            iorem
+        </span>
+    </span>
+</div>
+`;
 
     const documentationHtml = `<div>
     hello  world!
@@ -46,7 +56,7 @@ describe('collapseWhitespace', () => {
                 options
             );
         });
-		
+
         it('should not collapse whitespaces inside ' + inviolateTags, () => {
             return init(
                 inviolateTagsHtml,
@@ -64,6 +74,14 @@ describe('collapseWhitespace', () => {
             );
         });
 
+        it('should collapse whitespaces inside text node', () => {
+            return init(
+                spaceInsideTextNodeHtml,
+                '<div><span>lorem<span>iorem</span></span></div>',
+                options
+            );
+        });
+
         it('renders the documentation example correctly', () => {
             return init(
                 documentationHtml,
@@ -72,8 +90,8 @@ describe('collapseWhitespace', () => {
             );
         });
     });
-	
-	
+
+
     context('aggressive', () => {
         const options = {
             collapseWhitespace: 'aggressive',
@@ -104,10 +122,36 @@ describe('collapseWhitespace', () => {
             );
         });
 
+        it('should collapse whitespaces inside text node', () => {
+            return init(
+                spaceInsideTextNodeHtml,
+                '<div><span> lorem <span> iorem </span> </span></div>',
+                options
+            );
+        });
+
         it('renders the documentation example correctly', () => {
             return init(
                 documentationHtml,
                 '<div>hello world! <a href="#">answer</a> <style>div  { color: red; }  </style><main></main></div>',
+                options
+            );
+        });
+
+        it('test', () => {
+            const html = `
+<div class="post-meta">
+            <time datetime="2020-10-13T09:25:00.000Z">2020-10-13</time>
+                    <span class="dot">
+                     <span> </span>
+                    </span>
+        </div>`;
+
+            const expected = '<div class="post-meta"><time datetime="2020-10-13T09:25:00.000Z">2020-10-13</time> <span class="dot"> <span> </span> </span></div>';
+
+            return init(
+                html,
+                expected,
                 options
             );
         });
@@ -140,6 +184,14 @@ describe('collapseWhitespace', () => {
                 inviolateTagsHtml,
                 '<script> alert() </script><style>.foo  {}</style><pre> hello <b> , </b> </pre>' +
                 '<div> <!--  hello   world  --> </div><textarea> world! </textarea>',
+                options
+            );
+        });
+
+        it('should collapse whitespaces inside text node', () => {
+            return init(
+                spaceInsideTextNodeHtml,
+                '<div> <span> lorem <span> iorem </span> </span> </div>',
                 options
             );
         });


### PR DESCRIPTION
```html
<div> <span> </span> </div>
```

The whitespace between `<div>` & `<span>` and the whitespace between `</span>` & `</div>` are save to remove:

```html
<div><span> </span></div>
```

The PR implements it.