### PR TITLE
Chore: update babel configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,14 @@
   ],
   "babel": {
     "presets": [
-      "@babel/env"
+      [
+        "@babel/env",
+        {
+          "targets": {
+            "node": 10
+          }
+        }
+      ]
     ]
   },
   "dependencies": {


### PR DESCRIPTION
`posthtml` is targeting `Node.js > 10`. Thus we only need babel to transform ES Module to CommonJS Module. By adding `targets.node: 10` we can avoid unnecessary transformation & polyfill.