### PR TITLE
Feat: strip whitespaces between textnode & element

### DIFF
--- a/lib/modules/collapseWhitespace.es6
+++ b/lib/modules/collapseWhitespace.es6
@@ -76,21 +76,10 @@ function collapseRedundantWhitespaces(text, collapseType, shouldTrim = false, cu
     if (shouldTrim) {
         if (collapseType === 'aggressive') {
             if (onlyWhitespacePattern.test(text)) {
-                if (!noTrimWhitespacesArroundElements.has(currentTag)) {
-                    // Remove very first and very end spaces inside text node
-                    if (typeof prevNodeTag === 'undefined') {
-                        text = text.trimStart();
-                    }
-
-                    if (typeof nextNodeTag === 'undefined') {
-                        text = text.trimEnd();
-                    }
-                }
-
                 // "text" only contains whitespaces. Only trim when both prevNodeTag & nextNodeTag are not "noTrimWhitespacesArroundElement"
                 // Otherwise the required ONE whitespace will be trimmed
                 if (
-                    !noTrimWhitespacesArroundElements.has(prevNodeTag) &&
+                    !noTrimWhitespacesArroundElements.has(prevNodeTag) ||
                     !noTrimWhitespacesArroundElements.has(nextNodeTag)
                 ) {
                     text = text.trim();

--- a/test/modules/collapseWhitespace.js
+++ b/test/modules/collapseWhitespace.js
@@ -106,7 +106,7 @@ describe('collapseWhitespace', () => {
         it('should collapse redundant whitespaces and eliminate indentation (tabs, newlines, etc)', () => {
             return init(
                 html,
-                '<div><p>Hello world</p><pre>   <code>	posthtml    htmlnano     </code>	</pre> <code>posthtml htmlnano</code> <b> hello world! </b> <a>other link </a> Example</div>',
+                '<div><p>Hello world</p><pre>   <code>	posthtml    htmlnano     </code>	</pre><code>posthtml htmlnano</code> <b> hello world! </b> <a>other link </a> Example</div>',
                 options
             );
         });
@@ -115,7 +115,7 @@ describe('collapseWhitespace', () => {
             return init(
                 inviolateTagsHtml,
                 '<script> alert() </script><style>.foo  {}</style><pre> hello <b> , </b> </pre>' +
-                '<div><!--  hello   world  --></div> <textarea> world! </textarea>',
+                '<div><!--  hello   world  --></div><textarea> world! </textarea>',
                 options
             );
         });
@@ -139,7 +139,7 @@ describe('collapseWhitespace', () => {
         it('renders the documentation example correctly', () => {
             return init(
                 documentationHtml,
-                '<div>hello world! <a href="#">answer</a> <style>div  { color: red; }  </style><main></main></div>',
+                '<div>hello world! <a href="#">answer</a><style>div  { color: red; }  </style><main></main></div>',
                 options
             );
         });


### PR DESCRIPTION
```html
<a>Link</a> <div></div>
```

The whitespace between `</a>` & `<div>` is safe to remove, since `<a>` is an inline element while `<div>` is a block element.