### PR TITLE
Refactor: normalize regex pattern

### DIFF
--- a/lib/modules/collapseWhitespace.es6
+++ b/lib/modules/collapseWhitespace.es6
@@ -19,8 +19,8 @@ const noTrimWhitespacesInsideElements = new Set([
     'a', 'abbr', 'acronym', 'b', 'big', 'del', 'em', 'font', 'i', 'ins', 'kbd', 'mark', 'nobr', 'rp', 's', 'samp', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'time', 'tt', 'u', 'var'
 ]);
 
-const whitespacePattern = /[\f\n\r\t\v ]{1,}/g;
-const onlyWhitespacePattern = /^[\f\n\r\t\v ]+$/;
+const whitespacePattern = /\s{1,}/g;
+const onlyWhitespacePattern = /^\s+$/;
 const NONE = '';
 const SINGLE_SPACE = ' ';
 const validOptions = ['all', 'aggressive', 'conservative'];

--- a/lib/modules/removeOptionalTags.es6
+++ b/lib/modules/removeOptionalTags.es6
@@ -1,6 +1,6 @@
 import { isComment } from '../helpers';
 
-const startWithWhitespacePattern = /^[\f\n\r\t\v ]+/;
+const startWithWhitespacePattern = /^\s+/;
 
 const bodyStartTagCantBeOmittedWithFirstChildTags = new Set(['meta', 'link', 'script', 'style']);
 const tbodyStartTagCantBeOmittedWithPrecededTags = new Set(['tbody', 'thead', 'tfoot']);


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes):

> `\s` matches a single white space character, including space, tab, form feed, line feed, and other Unicode spaces. Equivalent to `[ \f\n\r\t\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]`.

