### PR TITLE
Fix: collapseWhitespaces around comment

### DIFF
--- a/lib/modules/collapseWhitespace.es6
+++ b/lib/modules/collapseWhitespace.es6
@@ -30,14 +30,13 @@ export default function collapseWhitespace(tree, options, collapseType, tag) {
     collapseType = validOptions.includes(collapseType) ? collapseType : 'conservative';
 
     tree.forEach((node, index) => {
-        if (typeof node === 'string' && !isComment(node)) {
+        if (typeof node === 'string') {
             const prevNode = tree[index - 1];
             const nextNode = tree[index + 1];
             const prevNodeTag = prevNode && prevNode.tag;
             const nextNodeTag = nextNode && nextNode.tag;
 
             const isTopLevel = !tag || tag === 'html' || tag === 'head';
-
             const shouldTrim = (
                 collapseType === 'all' ||
                 isTopLevel ||
@@ -71,7 +70,9 @@ function collapseRedundantWhitespaces(text, collapseType, shouldTrim = false, cu
         return NONE;
     }
 
-    text = text.replace(whitespacePattern, SINGLE_SPACE);
+    if (!isComment(text)) {
+        text = text.replace(whitespacePattern, SINGLE_SPACE);
+    }
 
     if (shouldTrim) {
         if (collapseType === 'aggressive') {


### PR DESCRIPTION
Due to a recent change from posthtml-parser (https://github.com/posthtml/posthtml-parser/commit/8e64082e9d084bcf42e100ef69c9af76132ff544), the comment is now parsed differently: 

```html
'<div>  <!-- comment -->  <div>'
```

will be parsed as:

```diff js
{content:
-  ["  ", "<!-- comment -->", "  ", Object {tag: "div"}] // before
+  ["  ", "<!-- comment -->  " // now
, tag: "div"}
```

The PR is to adapt to the behavior changes.

> After `rm -rf node_modules && npm i`, I notice that `npm test` no longer passes. Then I found out the behavior changes and bring up the PR. It is not a bug fix since it is only related to unit tests.

