### PR TITLE
Refactor: remove posthtml-render dependency

### DIFF
--- a/lib/modules/minifySvg.es6
+++ b/lib/modules/minifySvg.es6
@@ -1,5 +1,4 @@
 import SVGO from 'svgo';
-import posthtmlRender from 'posthtml-render';
 
 /** Minify SVG with SVGO */
 export default function minifySvg(tree, options, svgoOptions = {}) {
@@ -7,7 +6,7 @@ export default function minifySvg(tree, options, svgoOptions = {}) {
     let svgo = new SVGO(svgoOptions);
 
     tree.match({tag: 'svg'}, node => {
-        let svgStr = posthtmlRender(node);
+        let svgStr = tree.render(node);
         let promise = svgo.optimize(svgStr).then(result => {
             node.tag = false;
             node.attrs = {};

--- a/lib/modules/removeUnusedCss.es6
+++ b/lib/modules/removeUnusedCss.es6
@@ -1,7 +1,6 @@
 import { isStyleNode, extractCssFromStyleNode } from '../helpers';
 import uncss from 'uncss';
 import Purgecss from 'purgecss';
-import render from 'posthtml-render';
 
 // These options must be set and shouldn't be overriden to ensure uncss doesn't look at linked stylesheets.
 const uncssOptions = {
@@ -101,7 +100,7 @@ function runPurgecss(tree, css, userOptions) {
 /** Remove unused CSS */
 export default function removeUnusedCss(tree, options, userOptions) {
     const promises = [];
-    const html = userOptions.tool !== 'purgeCSS' && render(tree);
+    const html = userOptions.tool !== 'purgeCSS' && tree.render(tree);
 
     tree.walk(node => {
         if (isStyleNode(node)) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "cssnano": "^4.1.10",
     "posthtml": "^0.13.4",
-    "posthtml-render": "^1.3.0",
     "purgecss": "^2.3.0",
     "relateurl": "^0.2.7",
     "srcset": "^3.0.0",


### PR DESCRIPTION
`tree` already has its own `render` property, use it instead.