### PR TITLE
Fix: minifyConditionalComment with <html> support

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,27 +550,7 @@ Source:
 Minified:
 
 ```html
-<!--[if lte IE 7]><style>.title {color:red}</style><![endif]-->
-```
-
-##### Notice
-
-Due to [the limitation of PostHTML](https://github.com/posthtml/posthtml-parser/issues/9) (which is actually a issue from upstream [htmlparser2](https://github.com/fb55/htmlparser2/pull/146)), following html snippet is not supported:
-
-```html
-<!--[if lt IE 7]><html class="no-js ie6"><![endif]-->
-<!--[if IE 7]><html class="no-js ie7"><![endif]-->
-<!--[if IE 8]><html class="no-js ie8"><![endif]-->
-<!--[if gt IE 8]><!--><html class="no-js"><!--<![endif]-->
-```
-
-Which will result in:
-
-```html
-<!--[if lt IE 7]><html class="no-js ie6"></html><![endif]-->
-<!--[if IE 7]><html class="no-js ie7"></html><![endif]-->
-<!--[if IE 8]><html class="no-js ie8"></html><![endif]-->
-<!--[if gt IE 8]><!--><html class="no-js"></html><!--<![endif]-->
+<!--[if lte IE 7]><style>.title{color:red}</style><![endif]-->
 ```
 
 ### removeRedundantAttributes

--- a/lib/modules/minifyConditionalComments.es6
+++ b/lib/modules/minifyConditionalComments.es6
@@ -38,7 +38,12 @@ async function minifycontentInsideConditionalComments(text, htmlnanoOptions) {
 
     return Promise.all(matches.map(async match => {
         const result = await htmlnano.process(match[1], htmlnanoOptions, {}, {});
+        let minified = result.html;
 
-        return match[0] + result.html + match[2];
+        if (match[1].includes('<html') && minified.includes('</html>')) {
+            minified = minified.replace('</html>', '');
+        }
+
+        return match[0] + minified + match[2];
     }));
 }

--- a/test/modules/minifyConditionalComments.js
+++ b/test/modules/minifyConditionalComments.js
@@ -44,6 +44,16 @@ describe('minifyConditionalComments', () => {
         multipleConditionalCommentMinified: '<!--[if lt IE 7 ]><div class="ie6"> </div><![endif]--><!--[if IE 7 ]><div class="ie7"> </div><![endif]--><!--[if IE 8 ]><div class="ie8"> </div><![endif]--><!--[if IE 9 ]><div class="ie9"> </div><![endif]--><!--[if (gt IE 9)|!(IE)]><!--><div class="w3c"> </div>',
         singleLineMultipleConditionalComment: `
 <!--[if lt IE 7 ]><div class="ie6"></div><![endif]--><!--[if IE 7 ]><div class="ie7"></div><![endif]--><!--[if IE 8 ]><div class="ie8"></div><![endif]--><!--[if IE 9 ]><div class="ie9"></div><![endif]--><!--[if (gt IE 9)|!(IE)]><!--><div class="w3c"></div><!--<![endif]-->`,
+        htmlTagIncludedConditionalComment: `
+        <!--[if lt IE 7]><html class="no-js ie6"><![endif]-->
+        <!--[if IE 7]><html class="no-js ie7"><![endif]-->
+        <!--[if IE 8]><html class="no-js ie8"><![endif]-->
+        <!--[if gt IE 8]><!--><html class="no-js"><!--<![endif]-->`,
+        htmlTagIncludedConditionalCommentMinified: `
+        <!--[if lt IE 7]><html class="no-js ie6"><![endif]-->
+        <!--[if IE 7]><html class="no-js ie7"><![endif]-->
+        <!--[if IE 8]><html class="no-js ie8"><![endif]-->
+        <!--[if gt IE 8]><!--><html class="no-js"><!--<![endif]--></html>`
     };
 
     it('common html', () => {
@@ -72,6 +82,16 @@ describe('minifyConditionalComments', () => {
         return init(
             fixture.singleLineMultipleConditionalComment,
             fixture.singleLineMultipleConditionalComment,
+            {
+                minifyConditionalComments: true
+            }
+        );
+    });
+
+    it('<html> in conditional comment', () => {
+        return init(
+            fixture.htmlTagIncludedConditionalComment,
+            fixture.htmlTagIncludedConditionalCommentMinified,
             {
                 minifyConditionalComments: true
             }


### PR DESCRIPTION
With a dirty hack, [the limitation of PostHTML](https://github.com/posthtml/posthtml-parser/issues/9) (which is actually a issue from upstream [htmlparser2](https://github.com/fb55/htmlparser2/pull/146)) has been bypassed.