### PR TITLE
Perf: improve the performance of minifyJs

### DIFF
--- a/lib/modules/removeRedundantAttributes.es6
+++ b/lib/modules/removeRedundantAttributes.es6
@@ -1,5 +1,5 @@
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#JavaScript_types
-const redundantScriptTypes = new Set([
+export const redundantScriptTypes = new Set([
     'application/javascript',
     'application/ecmascript',
     'application/x-ecmascript',


### PR DESCRIPTION
[`tree.match`](https://github.com/posthtml/posthtml/blob/df802455e5b151fe80ceb3d509fef3bdd6f78e99/lib/api.js#L81-L95) will actually traverse through `tree` to find the matches according to its implementation, thus two `tree.match` means traverse through `tree` twice. By refactoring the code to `tree.walk` the `tree` will be traversed only once.