### PR TITLE
Update purgecss@4

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "cssnano": "^4.1.11",
     "posthtml": "^0.15.1",
-    "purgecss": "^2.3.0",
+    "purgecss": "^4.0.0",
     "relateurl": "^0.2.7",
     "srcset": "^3.0.0",
     "svgo": "^1.3.2",

--- a/test/modules/removeUnusedCss.js
+++ b/test/modules/removeUnusedCss.js
@@ -114,7 +114,7 @@ describe('removeUnusedCss (purgeCSS)', function () {
             {
                 removeUnusedCss: {
                     tool: 'purgeCSS',
-                    whitelist: ['c']
+                    safelist: ['c']
                 }
             }
         );


### PR DESCRIPTION
One options in purgecss has been renamed `whitelist` ➡️ `safelist` causing a breaking change.

I think after updating cssnano to [v5.0.0](https://github.com/cssnano/cssnano/tree/cssnano%405.0.0), htmlnano will be fully running on PostcSS 8. I couldn't figure out the upgrade path yet.