### PR TITLE
Update cssnano@5

### DIFF
--- a/lib/modules/minifyCss.es6
+++ b/lib/modules/minifyCss.es6
@@ -1,4 +1,5 @@
 import { isStyleNode, extractCssFromStyleNode } from '../helpers';
+import postcss from 'postcss';
 import cssnano from 'cssnano';
 
 const postcssOptions = {
@@ -36,8 +37,8 @@ function processStyleNode(styleNode, cssnanoOptions) {
         css = strippedCss;
     }
 
-    return cssnano
-        .process(css, postcssOptions, cssnanoOptions)
+    return postcss([cssnano(cssnanoOptions)])
+        .process(css, postcssOptions)
         .then(result => {
             if (isCdataWrapped) {
                 return styleNode.content = ['<![CDATA[' + result + ']]>'];
@@ -54,8 +55,8 @@ function processStyleAttr(node, cssnanoOptions) {
     const wrapperEnd = '}';
     const wrappedStyle = wrapperStart + (node.attrs.style || '') + wrapperEnd;
 
-    return cssnano
-        .process(wrappedStyle, postcssOptions, cssnanoOptions)
+    return postcss([cssnano(cssnanoOptions)])
+        .process(wrappedStyle, postcssOptions)
         .then(result => {
             const minifiedCss = result.css;
             // Remove wrapperStart at the start and wrapperEnd at the end of minifiedCss

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     ]
   },
   "dependencies": {
-    "cssnano": "^4.1.11",
+    "cssnano": "^5.0.0",
+    "postcss": "^8.2.9",
     "posthtml": "^0.15.1",
     "purgecss": "^2.3.0",
     "relateurl": "^0.2.7",

--- a/test/modules/minifyCss.js
+++ b/test/modules/minifyCss.js
@@ -31,7 +31,7 @@ describe('minifyCss', function () {
     it('should minify CSS inside <style>', () => {
         return init(
             html,
-            '<div><style>h1{margin:10px;color:red;-moz-border-radius:10px;border-radius:10px}</style></div>',
+            '<div><style>h1{-moz-border-radius:10px;border-radius:10px;color:red;margin:10px}</style></div>',
             options
         );
     });
@@ -58,7 +58,7 @@ describe('minifyCss', function () {
     it('should pass options to cssnano', () => {
         return init(
             html,
-            '<div><style>h1{margin:10px;color:#ff0000;-moz-border-radius:10px;border-radius:10px}</style></div>',
+            '<div><style>h1{-moz-border-radius:10px;border-radius:10px;color:#ff0000;margin:10px}</style></div>',
             {
                 minifyCss: {
                     preset: ['default', {
@@ -91,7 +91,7 @@ describe('minifyCss', function () {
     it('should keep CSS inside SVG wrapped in CDATA', () => {
         return init(
             svg,
-            '<svg><style><![CDATA[h1{margin:10px;color:red;-moz-border-radius:10px;border-radius:10px}]]></style></svg>',
+            '<svg><style><![CDATA[h1{-moz-border-radius:10px;border-radius:10px;color:red;margin:10px}]]></style></svg>',
             options
         );
     });


### PR DESCRIPTION
Hello, I want to update cssnano to reduce the amount of depencies in my projects that use the latest cssnano version.

Since PostCSS 7 is currently installed with the purgecss (I made a PR to update it https://github.com/posthtml/htmlnano/pull/138/files), I have to specify PostCSS 8 as a direct dependency to make sure it imports the correct version.

For the Javascript API of cssnano, I copy this https://github.com/cssnano/cssnano/blob/master/packages/cssnano/src/__tests__/_processCss.js