### PR TITLE
Add the ability to skip config loading entirely

### DIFF
--- a/lib/htmlnano.es6
+++ b/lib/htmlnano.es6
@@ -12,20 +12,22 @@ const presets = {
 };
 
 export function loadConfig(options, preset, configPath) {
-    const explorer = cosmiconfigSync(packageJson.name);
-    const rc = configPath ? explorer.load(configPath) : explorer.search();
-    if (rc) {
-        const { preset: presetName } = rc.config;
-        if (presetName) {
-            if (! preset && presets[presetName]) {
-                preset = presets[presetName];
+    if (! options?.skipConfigLoading) {
+        const explorer = cosmiconfigSync(packageJson.name);
+        const rc = configPath ? explorer.load(configPath) : explorer.search();
+        if (rc) {
+            const { preset: presetName } = rc.config;
+            if (presetName) {
+                if (! preset && presets[presetName]) {
+                    preset = presets[presetName];
+                }
+    
+                delete rc.config.preset;
             }
-
-            delete rc.config.preset;
-        }
-
-        if (! options) {
-            options = rc.config;
+    
+            if (! options) {
+                options = rc.config;
+            }
         }
     }
 

--- a/test/htmlnano.js
+++ b/test/htmlnano.js
@@ -48,6 +48,13 @@ describe('loadConfig()', () => {
             maxPreset
         ]);
     });
+
+    it('should not load options and preset from RC files if skipConfigLoading is true', () => {
+        expect(loadConfig({ skipConfigLoading: true }, undefined, './test/testrc.json')).toEqual([
+            { skipConfigLoading: true },
+            safePreset
+        ]);
+    });
 });
 
 


### PR DESCRIPTION
For bundlers like Parcel it's usually a good thing to be able to opt-out of config loading so we can allow our users to use a memory filesystem, browser-compatibility and reliable caching.

Alternatively we could do something like this:

```js
// loads the config, returning the filepath, options and preset
export function loadConfig(options, preset) {}

// runs htmlnano as it did before the config introduction
export function htmlnanoCore(options, preset) {}

// loads config and runs htmlnanoCore
export function htmlnano(options, preset) {}
```