### PR TITLE
Avoid deprecated SVGO function

### DIFF
--- a/docs/docs/050-modules.md
+++ b/docs/docs/050-modules.md
@@ -328,14 +328,18 @@ SVGO options can be passed directly to the `minifySvg` module:
 ```js
 htmlnano.process(html, {
     minifySvg: {
-        plugins: extendDefaultPlugins([
+        plugins: [
             {
-                name: 'builtinPluginName',
+                name: 'preset-default',
                 params: {
-                    optionName: 'optionValue'
-                }
+                    overrides: {
+                        builtinPluginName: {
+                            optionName: 'optionValue'
+                        },
+                    },
+                },
             }
-        ])
+        ]
     }
 });
 ```

--- a/lib/presets/safe.es6
+++ b/lib/presets/safe.es6
@@ -1,5 +1,3 @@
-import { extendDefaultPlugins } from 'svgo';
-
 /**
  * Minify HTML in a safe way without breaking anything.
  */
@@ -21,10 +19,17 @@ export default {
     minifyJs: {},
     minifyJson: {},
     minifySvg: {
-        plugins: extendDefaultPlugins([
-            { name: 'collapseGroups', active: false },
-            { name: 'convertShapeToPath', convertShapeToPath: false },
-        ]),
+        plugins: [
+            {
+                name: 'preset-default',
+                params: {
+                    overrides: {
+                        collapseGroups: false,
+                        convertShapeToPath: false,
+                    },
+                },
+            },
+        ]
     },
     minifyConditionalComments: false,
     removeEmptyAttributes: true,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "purgecss": "^4.0.0",
     "relateurl": "^0.2.7",
     "srcset": "^4.0.0",
-    "svgo": "^2.3.0",
+    "svgo": "^2.4.0",
     "terser": "^5.7.0",
     "timsort": "^0.3.0",
     "uncss": "^0.17.3"

--- a/test/modules/minifySvg.js
+++ b/test/modules/minifySvg.js
@@ -1,4 +1,3 @@
-import { extendDefaultPlugins } from 'svgo';
 import { init } from '../htmlnano';
 import safePreset from '../../lib/presets/safe';
 import maxPreset from '../../lib/presets/max';
@@ -60,9 +59,16 @@ describe('minifySvg', () => {
 
             {
                 minifySvg: {
-                    plugins: extendDefaultPlugins([
-                        { name: 'convertColors', active: false }
-                    ])
+                    plugins: [
+                        {
+                            name: 'preset-default',
+                            params: {
+                                overrides: {
+                                    convertColors: false,
+                                },
+                            },
+                        },
+                    ]
                 }
             }
         );


### PR DESCRIPTION
I hit the same issue as #150, ended up with the same fix as #151 but hopefully complete (the only remaining reference is in versioned_docs, which I guess is a historic snapshot that shouldn't be changed?)