### PR TITLE
Feat: custom matcher for removeComments module

### DIFF
--- a/docs/docs/050-modules.md
+++ b/docs/docs/050-modules.md
@@ -80,16 +80,66 @@ Minified:
 #### Options
 - `safe` – removes all HTML comments except the conditional comments and  [`<!--noindex--><!--/noindex-->`](https://yandex.com/support/webmaster/controlling-robot/html.xml) (default)
 - `all` — removes all HTML comments
+- A `RegExp` — only HTML comments matching the given regexp will be removed.
+- A `Function` that returns boolean — removes HTML comments that can make the given callback function returns truthy value.
 
 #### Example
+
 Source:
+
+```js
+{
+    removeComments: 'all'
+}
+```
+
 ```html
 <div><!-- test --></div>
 ```
 
 Minified:
+
 ```html
 <div></div>
+```
+
+Source:
+
+```js
+{
+    removeComments: /<!--(\/)?noindex-->/
+}
+```
+
+```html
+<div><!--noindex-->this text will not be indexed<!--/noindex-->Lorem ipsum dolor sit amet<!--more-->Lorem ipsum dolor sit amet</div>
+```
+
+Minified:
+
+```html
+<div>this text will not be indexedLorem ipsum dolor sit amet<!--more-->Lorem ipsum dolor sit amet</div>
+```
+
+Source:
+
+```js
+{
+    removeComments: (comments) => {
+        if (comments.includes('noindex')) return true;
+        return false;
+    }
+}
+```
+
+```html
+<div><!--noindex-->this text will not be indexed<!--/noindex-->Lorem ipsum dolor sit amet<!--more-->Lorem ipsum dolor sit amet</div>
+```
+
+Minified:
+
+```html
+<div>this text will not be indexedLorem ipsum dolor sit amet<!--more-->Lorem ipsum dolor sit amet</div>
 ```
 
 

--- a/lib/modules/removeComments.es6
+++ b/lib/modules/removeComments.es6
@@ -4,7 +4,7 @@ const MATCH_EXCERPT_REGEXP = /<!-- ?more ?-->/i;
 
 /** Removes HTML comments */
 export default function removeComments(tree, options, removeType) {
-    if (removeType !== 'all' && removeType !== 'safe') {
+    if (removeType !== 'all' && removeType !== 'safe' && !isMatcher(removeType)) {
         removeType = 'safe';
     }
 
@@ -62,5 +62,29 @@ function isCommentToRemove(text, removeType) {
         }
     }
 
+    if (isMatcher(removeType)) {
+        return isMatch(text, removeType);
+    }
+
     return true;
+}
+
+function isMatch(input, matcher) {
+    if (matcher instanceof RegExp) {
+        return matcher.test(input);
+    }
+
+    if (typeof matcher === 'function') {
+        return Boolean(matcher(input));
+    }
+
+    return false;
+}
+
+function isMatcher(matcher) {
+    if (matcher instanceof RegExp || typeof matcher === 'function') {
+        return true;
+    }
+
+    return false;
 }

--- a/test/modules/removeComments.js
+++ b/test/modules/removeComments.js
@@ -88,4 +88,29 @@ describe('removeComments', () => {
             );
         });
     });
+
+    context('custom matcher', () => {
+        it('RegExp', () => {
+            return init(
+                '<!--noindex-->this text will not be indexed<!--/noindex-->Lorem ipsum dolor sit amet<!--more-->Lorem ipsum dolor sit amet',
+                'this text will not be indexedLorem ipsum dolor sit amet<!--more-->Lorem ipsum dolor sit amet',
+                {
+                    removeComments: /<!--(\/)?noindex-->/,
+                }
+            );
+        });
+
+        it('Function', () => {
+            return init(
+                '<!--noindex-->this text will not be indexed<!--/noindex-->Lorem ipsum dolor sit amet<!--more-->Lorem ipsum dolor sit amet',
+                'this text will not be indexedLorem ipsum dolor sit amet<!--more-->Lorem ipsum dolor sit amet',
+                {
+                    removeComments: (comments) => {
+                        if (comments.includes('noindex')) return true;
+                        return false;
+                    },
+                }
+            );
+        });
+    });
 });


### PR DESCRIPTION
This implements #73

I'd like to introduce more options (like `whiteList` and `blackList`), which will require the `removeComments` module option to be an object. So I'd prefer to leave those changes to the next major version of htmlnano so that we can introduce it as a breaking change.

Also, cc @SoftCreatR