### PR TITLE
Feat: collapsing missing value default attribute

### DIFF
--- a/test/modules/removeRedundantAttributes.js
+++ b/test/modules/removeRedundantAttributes.js
@@ -119,7 +119,7 @@ describe('removeRedundantAttributes', () => {
         );
     });
 
-    it('should remove preload="metadata" from <audio> & <video>', () => {
+    it('should not remove preload="metadata" from <audio> & <video>', () => {
         return init(
             '<audio src="example.com" preload="metadata"></audio><video src="example.com" preload="metadata"></video>',
             '<audio src="example.com" preload="metadata"></audio><video src="example.com" preload="metadata"></video>',

--- a/test/modules/removeRedundantAttributes.js
+++ b/test/modules/removeRedundantAttributes.js
@@ -110,4 +110,20 @@ describe('removeRedundantAttributes', () => {
             options
         );
     });
+
+    it('should remove preload="auto" from <audio> & <video>', () => {
+        return init(
+            '<audio src="example.com" preload="auto"></audio><video src="example.com" preload="auto"></video>',
+            '<audio src="example.com" preload=""></audio><video src="example.com" preload=""></video>',
+            options
+        );
+    });
+
+    it('should remove preload="metadata" from <audio> & <video>', () => {
+        return init(
+            '<audio src="example.com" preload="metadata"></audio><video src="example.com" preload="metadata"></video>',
+            '<audio src="example.com" preload="metadata"></audio><video src="example.com" preload="metadata"></video>',
+            options
+        );
+    });
 });


### PR DESCRIPTION
In the spec, some attributes have `missing value default` (default state when an empty string is provided). This can be used to reduce output size even further.