### PR TITLE
Feat: minifyJs and minifyUrls enhancement

### DIFF
--- a/lib/modules/minifyJs.es6
+++ b/lib/modules/minifyJs.es6
@@ -71,8 +71,8 @@ function processScriptNode(scriptNode, terserOptions) {
 
 
 function processNodeWithOnAttrs(node, terserOptions) {
-    const jsWrapperStart = 'function _(){';
-    const jsWrapperEnd = '}';
+    const jsWrapperStart = 'function a(){';
+    const jsWrapperEnd = '}a();';
 
     const promises = [];
     for (const attrName of Object.keys(node.attrs || {})) {

--- a/test/modules/minifyUrls.js
+++ b/test/modules/minifyUrls.js
@@ -98,4 +98,12 @@ describe('minifyUrls', () => {
             { ...safePreset, minifyUrls: 'https://example.com/foo/baz/' }
         );
     });
+
+    it('should minify javascript url', () => {
+        init(
+            '<img src="javascript:alert(true)">',
+            '<img src="javascript:alert(!0)">',
+            { ...safePreset, minifyUrls: 'https://example.com/foo/baz/' }
+        );
+    });
 });


### PR DESCRIPTION
- Update `minifyJs` wrapper, to prevent tree shaking from strip the entire function.
- Update `minifyUrl` to support javascript URL minification.