### PR TITLE
Feat: supports optional dependencies

### DIFF
--- a/docs/docs/050-modules.md
+++ b/docs/docs/050-modules.md
@@ -203,6 +203,16 @@ or [PurgeCSS](https://github.com/FullHuman/purgecss).
 
 #### With uncss
 
+You have to install `uncss` in order to use this feature:
+
+```bash
+npm install --save-dev uncss
+# if you prefer yarn
+# yarn add --dev uncss
+# if you prefer pnpm
+# pnpm install --save-dev uncss
+```
+
 ##### Options
 See [the documentation of uncss](https://github.com/uncss/uncss) for all supported options.
 
@@ -224,6 +234,16 @@ The following uncss options are ignored if passed to the module:
 #### With PurgeCSS
 
 Use PurgeCSS instead of uncss by adding `tool: 'purgeCSS'` to the options.
+
+You have to install `purgecss` in order to use this feature:
+
+```bash
+npm install --save-dev purgecss
+# if you prefer yarn
+# yarn add --dev purgecss
+# if you prefer pnpm
+# pnpm install --save-dev purgecss
+```
 
 ##### Options
 
@@ -275,6 +295,16 @@ Optimized:
 ### minifyCss
 Minifies CSS with [cssnano](http://cssnano.co/) inside `<style>` tags and `style` attributes.
 
+You have to install `cssnano` and `postcss` in order to use this feature:
+
+```bash
+npm install --save-dev cssnano postcss
+# if you prefer yarn
+# yarn add --dev cssnano postcss
+# if you prefer pnpm
+# pnpm install --save-dev cssnano postcss
+```
+
 #### Options
 See [the documentation of cssnano](http://cssnano.co/docs/optimisations/) for all supported optimizations.
 By default CSS is minified with preset `default`, which shouldn't have any side-effects.
@@ -315,6 +345,16 @@ Minified:
 
 ### minifyJs
 Minifies JS using [Terser](https://github.com/fabiosantoscode/terser) inside `<script>` tags.
+
+You have to install `terser` in order to use this feature:
+
+```bash
+npm install --save-dev terser
+# if you prefer yarn
+# yarn add --dev terser
+# if you prefer pnpm
+# pnpm install --save-dev terser
+```
 
 #### Options
 See [the documentation of Terser](https://github.com/fabiosantoscode/terser#api-reference) for all supported options.
@@ -663,6 +703,16 @@ Processed:
 
 ### minifyUrls
 Convert absolute URL to relative URL using [relateurl](https://www.npmjs.com/package/relateurl).
+
+You have to install `relateurl`, `terser` and `srcset` in order to use this feature:
+
+```bash
+npm install --save-dev relateurl terser srcset
+# if you prefer yarn
+# yarn add --dev relateurl terser srcset
+# if you prefer pnpm
+# pnpm install --save-dev relateurl terser srcset
+```
 
 #### Options
 

--- a/lib/helpers.es6
+++ b/lib/helpers.es6
@@ -35,3 +35,14 @@ export function extractCssFromStyleNode(node) {
 export function isEventHandler(attributeName) {
     return attributeName && attributeName.slice && attributeName.slice(0, 2).toLowerCase() === 'on' && attributeName.length >= 5;
 }
+
+export function optionalRequire(moduleName) {
+    try {
+        return require(moduleName);
+    } catch (e) {
+        if (e.code === 'MODULE_NOT_FOUND') {
+            return null;
+        }
+        throw e;
+    }
+}

--- a/lib/modules/minifyCss.es6
+++ b/lib/modules/minifyCss.es6
@@ -1,6 +1,7 @@
-import { isStyleNode, extractCssFromStyleNode } from '../helpers';
-import postcss from 'postcss';
-import cssnano from 'cssnano';
+import { isStyleNode, extractCssFromStyleNode, optionalRequire } from '../helpers';
+
+const cssnano = optionalRequire('cssnano');
+const postcss = optionalRequire('postcss');
 
 const postcssOptions = {
     // Prevent the following warning from being shown:
@@ -11,6 +12,10 @@ const postcssOptions = {
 
 /** Minify CSS with cssnano */
 export default function minifyCss(tree, options, cssnanoOptions) {
+    if (!cssnano || !postcss) {
+        return tree;
+    }
+
     let promises = [];
     tree.walk(node => {
         if (isStyleNode(node)) {

--- a/lib/modules/minifyJs.es6
+++ b/lib/modules/minifyJs.es6
@@ -1,10 +1,12 @@
-import terser from 'terser';
-import { isEventHandler } from '../helpers';
+import { isEventHandler, optionalRequire } from '../helpers';
 import { redundantScriptTypes } from './removeRedundantAttributes';
 
+const terser = optionalRequire('terser');
 
 /** Minify JS with Terser */
 export default function minifyJs(tree, options, terserOptions) {
+    if (!terser) return tree;
+
     let promises = [];
     tree.walk(node => {
         if (node.tag && node.tag === 'script') {

--- a/lib/modules/minifySvg.es6
+++ b/lib/modules/minifySvg.es6
@@ -1,10 +1,14 @@
-import { optimize } from 'svgo';
+import { optionalRequire } from '../helpers';
+
+const svgo = optionalRequire('svgo');
 
 /** Minify SVG with SVGO */
 export default function minifySvg(tree, options, svgoOptions = {}) {
+    if (!svgo) return tree;
+
     tree.match({tag: 'svg'}, node => {
         let svgStr = tree.render(node, { closingSingleTag: 'slash', quoteAllAttributes: true });
-        const result = optimize(svgStr, svgoOptions);
+        const result = svgo.optimize(svgStr, svgoOptions);
         node.tag = false;
         node.attrs = {};
         node.content = result.data;

--- a/lib/modules/removeUnusedCss.es6
+++ b/lib/modules/removeUnusedCss.es6
@@ -1,6 +1,7 @@
-import { isStyleNode, extractCssFromStyleNode } from '../helpers';
-import uncss from 'uncss';
-import Purgecss from 'purgecss';
+import { isStyleNode, extractCssFromStyleNode, optionalRequire } from '../helpers';
+
+const uncss = optionalRequire('uncss');
+const purgecss = optionalRequire('purgecss');
 
 // These options must be set and shouldn't be overriden to ensure uncss doesn't look at linked stylesheets.
 const uncssOptions = {
@@ -90,7 +91,7 @@ function runPurgecss(tree, css, userOptions) {
         }]
     };
 
-    return new Purgecss()
+    return new purgecss.PurgeCSS()
         .purge(options)
         .then((result) => {
             return result[0].css;
@@ -105,9 +106,13 @@ export default function removeUnusedCss(tree, options, userOptions) {
     tree.walk(node => {
         if (isStyleNode(node)) {
             if (userOptions.tool === 'purgeCSS') {
-                promises.push(processStyleNodePurgeCSS(tree, node, userOptions));
+                if (purgecss) {
+                    promises.push(processStyleNodePurgeCSS(tree, node, userOptions));
+                }
             } else {
-                promises.push(processStyleNodeUnCSS(html, node, userOptions));
+                if (uncss) {
+                    promises.push(processStyleNodeUnCSS(html, node, userOptions));
+                }
             }
         }
         return node;

--- a/package.json
+++ b/package.json
@@ -40,16 +40,8 @@
   },
   "dependencies": {
     "cosmiconfig": "^7.0.1",
-    "cssnano": "^5.0.8",
-    "postcss": "^8.3.6",
     "posthtml": "^0.16.5",
-    "purgecss": "^4.0.0",
-    "relateurl": "^0.2.7",
-    "srcset": "^4.0.0",
-    "svgo": "^2.6.1",
-    "terser": "^5.8.0",
-    "timsort": "^0.3.0",
-    "uncss": "^0.17.3"
+    "timsort": "^0.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.7",
@@ -57,11 +49,55 @@
     "@babel/preset-env": "^7.15.6",
     "@babel/register": "^7.15.3",
     "babel-eslint": "^10.1.0",
+    "cssnano": "^5.0.11",
     "eslint": "^7.32.0",
     "expect": "^27.2.0",
     "mocha": "^9.1.0",
+    "postcss": "^8.3.11",
+    "purgecss": "^4.0.3",
+    "relateurl": "^0.2.7",
     "release-it": "^14.11.5",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "srcset": "^5.0.0",
+    "svgo": "^2.8.0",
+    "terser": "^5.10.0",
+    "uncss": "^0.17.3"
+  },
+  "peerDependencies": {
+    "cssnano": "^5.0.11",
+    "postcss": "^8.3.11",
+    "purgecss": "^4.0.3",
+    "relateurl": "^0.2.7",
+    "srcset": "^5.0.0",
+    "svgo": "^2.8.0",
+    "terser": "^5.10.0",
+    "uncss": "^0.17.3"
+  },
+  "peerDependenciesMeta": {
+    "cssnano": {
+      "optional": true
+    },
+    "postcss": {
+      "optional": true
+    },
+    "purgecss": {
+      "optional": true
+    },
+    "relateurl": {
+      "optional": true
+    },
+    "srcset": {
+      "optional": true
+    },
+    "svgo": {
+      "optional": true
+    },
+    "terser": {
+      "optional": true
+    },
+    "uncss": {
+      "optional": true
+    }
   },
   "repository": {
     "type": "git",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import { isAmpBoilerplate, isComment, isConditionalComment, isStyleNode, extractCssFromStyleNode } from '../lib/helpers';
+import { isAmpBoilerplate, isComment, isConditionalComment, isStyleNode, extractCssFromStyleNode, optionalRequire } from '../lib/helpers';
 
 describe('[helpers]', () => {
     context('isAmpBoilerplate()', () => {
@@ -55,6 +55,16 @@ describe('[helpers]', () => {
                     'def',
                 ],
             })).toBe('abc def');
+        });
+    });
+
+    context('optionalRequire()', () => {
+        it('should return the dependency when resolved', () => {
+            expect(optionalRequire('expect')).toBe(expect);
+        });
+
+        it('should return null when module not found', () => {
+            expect(optionalRequire('null')).toBe(null);
         });
     });
 });

--- a/test/htmlnano.js
+++ b/test/htmlnano.js
@@ -24,6 +24,13 @@ describe('[htmlnano]', () => {
             expect(error.message).toBe('Module "notDefinedModule" is not defined');
         });
     });
+
+    it('getRequiredOptionalDependencies', () => {
+        expect(htmlnano.getRequiredOptionalDependencies({
+            minifyUrl: true,
+            minifyJs: {}
+        })).toStrictEqual(['relateurl', 'srcset', 'terser']);
+    });
 });
 
 


### PR DESCRIPTION
Fix #165, close #166.

Make `terser`, `cssnano`, `uncss`, etc. optional.

**BREAKING CHANGES**

Only merge it when it is about to bump a major version.

----

@maltsev What about creating a new branch `v2`? I'd like to introduce other breaking changes on top of this PR (like making `purgecss` default instead of `uncss`). With a new branch, we can only merge breaking changes into `master` when `2.0.0` is about to release.