### PR TITLE
Disable mergeScripts & mergeStyles in safe preset

### DIFF
--- a/lib/presets/max.es6
+++ b/lib/presets/max.es6
@@ -8,6 +8,8 @@ export default { ...safePreset,
     removeComments: 'all',
     removeAttributeQuotes: true,
     removeRedundantAttributes: true,
+    mergeScripts: true,
+    mergeStyles: true,
     removeUnusedCss: {},
     minifyCss: {
         preset: 'default',

--- a/lib/presets/safe.es6
+++ b/lib/presets/safe.es6
@@ -10,8 +10,8 @@ export default {
     collapseWhitespace: 'conservative',
     custom: [],
     deduplicateAttributeValues: true,
-    mergeScripts: true,
-    mergeStyles: true,
+    mergeScripts: false,
+    mergeStyles: false,
     removeUnusedCss: false,
     minifyCss: {
         preset: 'default',

--- a/test/modules/mergeScripts.js
+++ b/test/modules/mergeScripts.js
@@ -1,10 +1,10 @@
 import { init } from '../htmlnano';
-import safePreset from '../../lib/presets/safe';
+import maxPreset from '../../lib/presets/max';
 
 
 describe('mergeScripts', () => {
     const options = {
-        mergeScripts: safePreset.mergeScripts,
+        mergeScripts: maxPreset.mergeScripts,
     };
 
     it('should merge <script> with the same attributes', () => {

--- a/test/modules/mergeStyles.js
+++ b/test/modules/mergeStyles.js
@@ -1,10 +1,10 @@
 import { init } from '../htmlnano';
-import safePreset from '../../lib/presets/safe';
+import maxPreset from '../../lib/presets/max';
 
 
 describe('mergeStyles', () => {
     const options = {
-        mergeStyles: safePreset.mergeStyles,
+        mergeStyles: maxPreset.mergeStyles,
     };
 
     it('should merge multiple <style> with the same "type" and "media" into one', () => {


### PR DESCRIPTION
Consider a case:

```html
<template>
  <!-- Maybe used in shadow dom or something -->
  <script>/* I shouldn't be executed when page is loaded! */</script>
</template>
```

htmlnano's `mergeScripts` and `mergeStyles` can't detect such a case and may cause unwanted behaviors by extracting and merging them to the top level.

There are many ways for a developer to make their own template (E.g. `<script type="mySecretTemplate"><script>/* I shouldn't be executed when page is loaded! */</script></script>`) and there is no way for htmlnano can identify them all. Thus those two features should be disabled in v2 by default.

Those two features can retain enabled by default in v1 since we haven't received any bug reports about the issue, yet.