### PR TITLE
Fix(#182): correct types and type checks

### DIFF
--- a/lib/modules/minifyJson.es6
+++ b/lib/modules/minifyJson.es6
@@ -2,15 +2,15 @@ const rNodeAttrsTypeJson = /(\/|\+)json/;
 
 export function onContent() {
     return (content, node) => {
-        let newContent = content;
         if (node.attrs && node.attrs.type && rNodeAttrsTypeJson.test(node.attrs.type)) {
             try {
-                newContent = JSON.stringify(JSON.parse((content || []).join('')));
+                // cast minified JSON to an array
+                return [JSON.stringify(JSON.parse((content || []).join('')))];
             } catch (error) {
                 // Invalid JSON
             }
         }
 
-        return newContent;
+        return content;
     };
 }

--- a/lib/modules/minifySvg.es6
+++ b/lib/modules/minifySvg.es6
@@ -11,7 +11,8 @@ export default function minifySvg(tree, options, svgoOptions = {}) {
         const result = svgo.optimize(svgStr, svgoOptions);
         node.tag = false;
         node.attrs = {};
-        node.content = result.data;
+        // result.data is a string, we need to cast it to an array
+        node.content = [result.data];
         return node;
     });
 


### PR DESCRIPTION
The PR closes #182.
X-Ref: https://github.com/parcel-bundler/parcel/issues/7906

PostHTML does supports `node.content` to be either a `string` or a `string[]` when stringify a PostHTML AST Tree into HTML, while PostHTML parser will only emit `node.content` as an array of string. So the new htmlnano module syntax (#128) just take it for granted that `node.content` will always be a `string[]`.

However, some htmlnano modules (`minifyJson` and `minifySvg`) will transform `node.content` into a `string` instead of a `string[]`, so when other modules (which expects `node.content` to be a `string[]`) process the new `node.content` later on, htmlnano will crash.

This PR fixes the issue by:

- Make sure `minifyJson`, `minifySvg`, and other modules will always return `string[]`.
- `node.content` will always be cast into an array before passed into `onContent`.
- The result from `onContent` will always be cast into an array.
- Add additional type check when applying new syntax modules.

cc @maltsev @AndrewKvalheim @mischnic @arneke 