### PR TITLE
Fix(collapseWhitespace): handle textNode when comment is preserved

### DIFF
--- a/lib/helpers.es6
+++ b/lib/helpers.es6
@@ -17,7 +17,10 @@ export function isAmpBoilerplate(node) {
 }
 
 export function isComment(content) {
-    return (content || '').trim().startsWith('<!--');
+    if (typeof content === 'string') {
+        return content.trim().startsWith('<!--');
+    }
+    return false;
 }
 
 export function isConditionalComment(content) {

--- a/lib/modules/collapseWhitespace.es6
+++ b/lib/modules/collapseWhitespace.es6
@@ -78,7 +78,12 @@ function collapseRedundantWhitespaces(text, collapseType, shouldTrim = false, pa
     if (shouldTrim) {
         if (collapseType === 'aggressive') {
             if (!noTrimWhitespacesInsideElements.has(parent && parent.node && parent.node.tag)) {
-                if (!noTrimWhitespacesArroundElements.has(prevNode && prevNode.tag)) {
+                if (
+                    // It is the first child node of the parent
+                    !prevNode
+                    // It is not the first child node, and prevNode not a text node, and prevNode is safe to trim around
+                    || prevNode && prevNode.tag && !noTrimWhitespacesArroundElements.has(prevNode.tag)
+                ) {
                     text = text.trimStart();
                 } else {
                     // previous node is a "no trim whitespaces arround element"
@@ -99,7 +104,10 @@ function collapseRedundantWhitespaces(text, collapseType, shouldTrim = false, pa
                     }
                 }
 
-                if (!noTrimWhitespacesArroundElements.has(nextNode && nextNode.tag)) {
+                if (
+                    !nextNode
+                    || nextNode && nextNode.tag && !noTrimWhitespacesArroundElements.has(nextNode.tag)
+                ) {
                     text = text.trimEnd();
                 }
             } else {

--- a/test/modules/collapseWhitespace.js
+++ b/test/modules/collapseWhitespace.js
@@ -145,6 +145,14 @@ describe('collapseWhitespace', () => {
             );
         });
 
+        it('handle whitespace along with comment', () => {
+            return init(
+                '<div>before<!-- --> <!-- --><a href="#link"></a>  <!-- -->  <!-- --> after</div>',
+                '<div>before<!-- --> <!-- --><a href="#link"></a> <!-- --> <!-- --> after</div>',
+                options
+            );
+        });
+
         it('renders the documentation example correctly', () => {
             return init(
                 documentationHtml,


### PR DESCRIPTION
Fix a very rare edge case that `collapseWhitespace` module wrongly trim a whitespace when `removeComments` module is disabled. This PR makes sure the whitespace will not be trimmed when `prevNode` or `nextNode` is text nodes (or comments).