### PR TITLE
Docs(usage): encourage using gulp-posthtml instead of gulp-htmlnano

### DIFF
--- a/docs/docs/020-usage.md
+++ b/docs/docs/020-usage.md
@@ -1,26 +1,4 @@
 # Usage
-
-## Gulp
-```bash
-npm install --save-dev gulp-htmlnano
-```
-
-```js
-const gulp = require('gulp');
-const htmlnano = require('gulp-htmlnano');
-const options = {
-    removeComments: false
-};
-
-gulp.task('default', function() {
-    return gulp
-        .src('./index.html')
-        .pipe(htmlnano(options))
-        .pipe(gulp.dest('./build'));
-});
-```
-
-
 ## Javascript
 ```js
 const htmlnano = require('htmlnano');
@@ -74,4 +52,28 @@ posthtml(posthtmlPlugins)
     .catch(function (err) {
         console.error(err);
     });
+```
+
+## Gulp
+```bash
+npm i -D gulp-posthtml htmlnano
+```
+
+```js
+const gulp = require('gulp');
+const posthtml = require('gulp-posthtml');
+const htmlnano = require('htmlnano');
+const options = {
+    removeComments: false
+};
+
+gulp.task('default', function() {
+    return gulp
+        .src('./index.html')
+        .pipe(posthtml([
+            // Add `htmlnano` as a final plugin
+            htmlnano(options)
+        ]))
+        .pipe(gulp.dest('./build'));
+});
 ```


### PR DESCRIPTION
[`gulp-htmlnano`](https://github.com/posthtml/gulp-htmlnano) is not actively maintained and is kinda deprecated. And even gulp itself is not actively maintained anymore.

Encourage developers to use [`gulp-posthtml`](https://github.com/posthtml/gulp-posthtml) along with the latest version of posthtml & htmlnano.