### PR TITLE
Feat: further minify attribute values

### DIFF
--- a/lib/modules/collapseBooleanAttributes.es6
+++ b/lib/modules/collapseBooleanAttributes.es6
@@ -1,5 +1,6 @@
 // Source: https://github.com/kangax/html-minifier/issues/63
 // https://html.spec.whatwg.org/#boolean-attribute
+// https://html.spec.whatwg.org/#attributes-1
 const htmlBooleanAttributes = new Set([
     'allowfullscreen',
     'allowpaymentrequest',
@@ -28,12 +29,14 @@ const htmlBooleanAttributes = new Set([
     'multiple',
     'muted',
     'nohref',
+    'nomodule',
     'noresize',
     'noshade',
     'novalidate',
     'nowrap',
     'open',
     'pauseonexit',
+    'playsinline',
     'readonly',
     'required',
     'reversed',

--- a/lib/modules/collapseBooleanAttributes.es6
+++ b/lib/modules/collapseBooleanAttributes.es6
@@ -1,4 +1,5 @@
 // Source: https://github.com/kangax/html-minifier/issues/63
+// https://html.spec.whatwg.org/#boolean-attribute
 const htmlBooleanAttributes = new Set([
     'allowfullscreen',
     'allowpaymentrequest',
@@ -141,6 +142,11 @@ export function onAttrs(options, moduleOptions) {
             if (htmlBooleanAttributes.has(attrName)) {
                 newAttrs[attrName] = true;
             }
+
+            // Fast path optimization.
+            // The rest of tranformations are only for string type attrValue.
+            if (typeof newAttrs[attrName] !== 'string') continue;
+
             if (moduleOptions.amphtml && amphtmlBooleanAttributes.has(attrName) && attrs[attrName] === '') {
                 newAttrs[attrName] = true;
             }

--- a/lib/modules/normalizeAttributeValues.es6
+++ b/lib/modules/normalizeAttributeValues.es6
@@ -41,7 +41,7 @@ const invalidValueDefault = {
     crossorigin: {
         tag: null,
         default: 'anonymous',
-        valid: ['anonymous', 'use-credentials']
+        valid: ['', 'anonymous', 'use-credentials']
     },
     // https://html.spec.whatwg.org/#referrer-policy-attributes
     // The attribute's invalid value default and missing value default are both the empty string state.

--- a/lib/modules/normalizeAttributeValues.es6
+++ b/lib/modules/normalizeAttributeValues.es6
@@ -11,7 +11,7 @@ const caseInsensitiveAttributes = {
     kind: ['track'],
     method: ['form'],
     preload: ['audio', 'video'],
-    referrerpolicy: ['a', 'area', 'iframe', 'img', 'link'],
+    referrerpolicy: null,
     sandbox: ['iframe'],
     spellcheck: null,
     scope: ['th'],
@@ -114,6 +114,8 @@ export function onAttrs() {
         const newAttrs = attrs;
 
         Object.entries(attrs).forEach(([attrName, attrValue]) => {
+            let newAttrValue = attrValue;
+
             if (
                 Object.hasOwnProperty.call(caseInsensitiveAttributes, attrName)
                 && (
@@ -121,7 +123,7 @@ export function onAttrs() {
                     || caseInsensitiveAttributes[attrName].includes(node.tag)
                 )
             ) {
-                newAttrs[attrName] = attrValue.toLowerCase ? attrValue.toLowerCase() : attrValue;
+                newAttrValue = attrValue.toLowerCase ? attrValue.toLowerCase() : attrValue;
             }
 
             if (
@@ -129,11 +131,13 @@ export function onAttrs() {
             ) {
                 const meta = invalidValueDefault[attrName];
                 if (meta.tag === null || (node && node.tag && meta.tag.includes(node.tag))) {
-                    if (!meta.valid.includes(attrValue)) {
-                        newAttrs[attrName] = meta.default;
+                    if (!meta.valid.includes(newAttrValue)) {
+                        newAttrValue = meta.default;
                     }
                 }
             }
+
+            newAttrs[attrName] = newAttrValue;
         });
 
         return newAttrs;

--- a/lib/modules/normalizeAttributeValues.es6
+++ b/lib/modules/normalizeAttributeValues.es6
@@ -35,6 +35,80 @@ const caseInsensitiveAttributes = {
     wrap: ['textarea']
 };
 
+// https://html.spec.whatwg.org/#invalid-value-default
+/** @typedef { [key: string]: { tag: null | string[], default: string, valid: string[] } } */
+const invalidValueDefault = {
+    crossorigin: {
+        tag: null,
+        default: 'anonymous',
+        valid: ['anonymous', 'use-credentials']
+    },
+    // https://html.spec.whatwg.org/#referrer-policy-attributes
+    // The attribute's invalid value default and missing value default are both the empty string state.
+    referrerpolicy: {
+        tag: null,
+        default: '',
+        valid: ['', 'url', 'origin', 'no-referrer', 'no-referrer-when-downgrade', 'same-origin', 'origin-when-cross-origin', 'strict-origin-when-cross-origin', 'unsafe-url']
+    },
+    // https://html.spec.whatwg.org/#lazy-loading-attributes
+    loading: {
+        tag: ['img', 'iframe'],
+        default: 'eager',
+        valid: ['lazy', 'eager']
+    },
+    // https://html.spec.whatwg.org/#the-img-element
+    // https://html.spec.whatwg.org/#image-decoding-hint
+    decoding: {
+        tag: ['img'],
+        default: 'auto',
+        valid: ['auto', 'sync', 'async']
+    },
+    // https://html.spec.whatwg.org/#the-track-element
+    kind: {
+        tag: ['track'],
+        default: 'metadata',
+        valid: ['subtitles', 'captions', 'descriptions', 'chapters', 'metadata']
+    },
+    autocomplete: {
+        tag: null,
+        default: 'on',
+        valid: ['on', 'off']
+    },
+    type: {
+        tag: ['button'],
+        default: 'submit',
+        valid: ['submit', 'reset', 'button']
+    },
+    wrap: {
+        tag: ['textarea'],
+        default: 'soft',
+        valid: ['soft', 'hard']
+    },
+    // https://html.spec.whatwg.org/#the-hidden-attribute
+    hidden: {
+        tag: null,
+        default: 'hidden',
+        valid: ['hidden', 'until-found']
+    },
+    // https://html.spec.whatwg.org/#autocapitalization
+    autocapitalize: {
+        tag: null,
+        default: 'sentences',
+        valid: ['none', 'off', 'on', 'sentences', 'words', 'characters']
+    },
+    // https://html.spec.whatwg.org/#the-marquee-element
+    behavior: {
+        tag: ['marquee'],
+        default: 'scroll',
+        valid: ['scroll', 'slide', 'alternate']
+    },
+    direction: {
+        tag: ['marquee'],
+        default: 'left',
+        valid: ['left', 'right', 'up', 'down']
+    }
+};
+
 export function onAttrs() {
     return (attrs, node) => {
         const newAttrs = attrs;
@@ -48,6 +122,17 @@ export function onAttrs() {
                 )
             ) {
                 newAttrs[attrName] = attrValue.toLowerCase ? attrValue.toLowerCase() : attrValue;
+            }
+
+            if (
+                Object.hasOwnProperty.call(invalidValueDefault, attrName)
+            ) {
+                const meta = invalidValueDefault[attrName];
+                if (meta.tag === null || (node && node.tag && meta.tag.includes(node.tag))) {
+                    if (!meta.valid.includes(attrValue)) {
+                        newAttrs[attrName] = meta.default;
+                    }
+                }
             }
         });
 

--- a/lib/modules/removeRedundantAttributes.es6
+++ b/lib/modules/removeRedundantAttributes.es6
@@ -18,17 +18,19 @@ export const redundantScriptTypes = new Set([
     'text/x-javascript'
 ]);
 
+// https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#missing-value-default
 const redundantAttributes = {
     'form': {
         'method': 'get'
     },
 
-    'input': {
-        'type': 'text'
+    input: {
+        type: 'text'
     },
 
-    'button': {
-        'type': 'submit'
+    button: {
+        // https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type
+        type: 'submit'
     },
 
     'script': {
@@ -58,7 +60,7 @@ const redundantAttributes = {
     },
 
     'link': {
-        'media': 'all',
+        media: 'all',
         'type': attrs => {
             // https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet
             let isRelStyleSheet = false;
@@ -81,11 +83,28 @@ const redundantAttributes = {
     },
 
     // See: https://html.spec.whatwg.org/#lazy-loading-attributes
-    'img': {
+    img: {
+        'loading': 'eager',
+        // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decoding
+        decoding: 'auto'
+    },
+    iframe: {
         'loading': 'eager'
     },
-    'iframe': {
-        'loading': 'eager'
+
+    // https://html.spec.whatwg.org/multipage/media.html#htmltrackelement
+    track: {
+        kind: 'subtitles'
+    },
+
+    textarea: {
+        // https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-wrap
+        wrap: 'soft'
+    },
+
+    area: {
+        // https://html.spec.whatwg.org/multipage/image-maps.html#attr-area-shape
+        shape: 'rect'
     }
 };
 
@@ -99,40 +118,11 @@ const canBeReplacedWithEmptyStringAttributes = {
         preload: 'auto'
     },
 
-    form: {
-        // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute
-        autocomplete: 'on'
-    },
-
-    img: {
-        // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decoding
-        decoding: 'auto'
-    },
-
-    track: {
-        // https://html.spec.whatwg.org/multipage/media.html#htmltrackelement
-        kind: 'subtitles'
-    },
-
-    textarea: {
-        // https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-wrap
-        wrap: 'soft'
-    },
-
-    area: {
-        // https://html.spec.whatwg.org/multipage/image-maps.html#attr-area-shape
-        shape: 'rect'
-    },
-
-    button: {
-        // https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type
-        type: 'submit'
-    },
-
-    input: {
-        // https://html.spec.whatwg.org/multipage/input.html#states-of-the-type-attribute
-        type: 'text'
-    }
+    // Form autocomplete doesn't have a missing value default any more
+    // form: {
+    //     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute
+    //     autocomplete: 'on'
+    // }
 };
 
 const tagsHaveRedundantAttributes = new Set(Object.keys(redundantAttributes));

--- a/lib/modules/removeRedundantAttributes.es6
+++ b/lib/modules/removeRedundantAttributes.es6
@@ -19,7 +19,7 @@ export const redundantScriptTypes = new Set([
 ]);
 
 // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#missing-value-default
-const redundantAttributes = {
+const missingValueDefaultAttributes = {
     'form': {
         'method': 'get'
     },
@@ -108,25 +108,7 @@ const redundantAttributes = {
     }
 };
 
-// See: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#missing-value-default
-const canBeReplacedWithEmptyStringAttributes = {
-    audio: {
-        // https://html.spec.whatwg.org/#attr-media-preload
-        preload: 'auto'
-    },
-    video: {
-        preload: 'auto'
-    },
-
-    // Form autocomplete doesn't have a missing value default any more
-    // form: {
-    //     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute
-    //     autocomplete: 'on'
-    // }
-};
-
-const tagsHaveRedundantAttributes = new Set(Object.keys(redundantAttributes));
-const tagsHaveMissingValueDefaultAttributes = new Set(Object.keys(canBeReplacedWithEmptyStringAttributes));
+const tagsHaveMissingValueDefaultAttributes = new Set(Object.keys(missingValueDefaultAttributes));
 
 /** Removes redundant attributes */
 export function onAttrs() {
@@ -135,8 +117,8 @@ export function onAttrs() {
 
         const newAttrs = attrs;
 
-        if (tagsHaveRedundantAttributes.has(node.tag)) {
-            const tagRedundantAttributes = redundantAttributes[node.tag];
+        if (tagsHaveMissingValueDefaultAttributes.has(node.tag)) {
+            const tagRedundantAttributes = missingValueDefaultAttributes[node.tag];
 
             for (const redundantAttributeName of Object.keys(tagRedundantAttributes)) {
                 let tagRedundantAttributeValue = tagRedundantAttributes[redundantAttributeName];
@@ -150,23 +132,6 @@ export function onAttrs() {
 
                 if (isRemove) {
                     delete newAttrs[redundantAttributeName];
-                }
-            }
-        }
-
-        if (tagsHaveMissingValueDefaultAttributes.has(node.tag)) {
-            const tagMissingValueDefaultAttributes = canBeReplacedWithEmptyStringAttributes[node.tag];
-
-            for (const canBeReplacedWithEmptyStringAttributeName of Object.keys(tagMissingValueDefaultAttributes)) {
-                let tagMissingValueDefaultAttribute = tagMissingValueDefaultAttributes[canBeReplacedWithEmptyStringAttributeName];
-                let isReplace = false;
-
-                if (attrs[canBeReplacedWithEmptyStringAttributeName] === tagMissingValueDefaultAttribute) {
-                    isReplace = true;
-                }
-
-                if (isReplace) {
-                    newAttrs[canBeReplacedWithEmptyStringAttributeName] = '';
                 }
             }
         }

--- a/lib/presets/safe.es6
+++ b/lib/presets/safe.es6
@@ -4,6 +4,10 @@
 export default {
     sortAttributes: false,
     collapseAttributeWhitespace: true,
+    // normalizeAttributeValues will also normalize property value with invalid value default
+    // See https://html.spec.whatwg.org/#invalid-value-default
+    normalizeAttributeValues: true,
+    // collapseBooleanAttributes will also collapse those default state can be omitted
     collapseBooleanAttributes: {
         amphtml: false,
     },
@@ -32,8 +36,9 @@ export default {
         ]
     },
     minifyConditionalComments: false,
+    // collapseBooleanAttributes will remove attributes when missing value default matches the attribute's value
+    // See https://html.spec.whatwg.org/#missing-value-default
     removeRedundantAttributes: false,
-    normalizeAttributeValues: true,
     removeEmptyAttributes: true,
     removeComments: 'safe',
     removeAttributeQuotes: false,

--- a/lib/presets/safe.es6
+++ b/lib/presets/safe.es6
@@ -12,7 +12,6 @@ export default {
         amphtml: false,
     },
     collapseWhitespace: 'conservative',
-    custom: [],
     deduplicateAttributeValues: true,
     mergeScripts: false,
     mergeStyles: false,
@@ -45,4 +44,5 @@ export default {
     sortAttributesWithLists: 'alphabetical',
     minifyUrls: false,
     removeOptionalTags: false,
+    custom: []
 };

--- a/test/modules/collapseBooleanAttributes.js
+++ b/test/modules/collapseBooleanAttributes.js
@@ -25,14 +25,15 @@ describe('collapseBooleanAttributes', () => {
         );
     });
 
-
-    it('should not collapse non boolean attribute', () => {
-        return init(
-            '<a href="">link</a>',
-            '<a href="">link</a>',
-            options
-        );
-    });
+    // https://html.spec.whatwg.org/#a-quick-introduction-to-html
+    // The value, along with the "=" character, can be omitted altogether if the value is the empty string.
+    // it('should not collapse non boolean attribute', () => {
+    //     return init(
+    //         '<a href="">link</a>',
+    //         '<a href="">link</a>',
+    //         options
+    //     );
+    // });
 
 
     it('should collapse AMP boolean attributes with empty value', () => {
@@ -82,6 +83,22 @@ describe('collapseBooleanAttributes', () => {
         return init(
             '<script src="example-framework.js" crossorigin="use-credentials"></script>',
             '<script src="example-framework.js" crossorigin="use-credentials"></script>',
+            options
+        );
+    });
+
+    it('should remove preload="auto" from <audio> & <video>', () => {
+        return init(
+            '<audio src="example.com" preload="auto"></audio><video src="example.com" preload="auto"></video>',
+            '<audio src="example.com" preload></audio><video src="example.com" preload></video>',
+            options
+        );
+    });
+
+    it('should not remove preload="metadata" from <audio> & <video>', () => {
+        return init(
+            '<audio src="example.com" preload="metadata"></audio><video src="example.com" preload="metadata"></video>',
+            '<audio src="example.com" preload="metadata"></audio><video src="example.com" preload="metadata"></video>',
             options
         );
     });

--- a/test/modules/normalizeAttributeValues.js
+++ b/test/modules/normalizeAttributeValues.js
@@ -29,7 +29,14 @@ describe('normalizeAttributeValues', () => {
                 // while input's invalid default value is ignored in out implementation
                 '<button type="submit"></button><input type="example">',
                 options
-            )
+            ),
+            // make sure case normalization is applied before invalid value default
+            init(
+                '<a referrerpolicy="uNSaFe-UrL"></a>',
+                // should be lower case instead of invalid value default
+                '<a referrerpolicy="unsafe-url"></a>',
+                options
+            ),
         ]);
     });
 });

--- a/test/modules/normalizeAttributeValues.js
+++ b/test/modules/normalizeAttributeValues.js
@@ -2,13 +2,34 @@ import { init } from '../htmlnano';
 import safePreset from '../../lib/presets/safe';
 
 describe('normalizeAttributeValues', () => {
-    const options = safePreset;
+    const options = {
+        normalizeAttributeValues: true
+    };
 
     it('default behavior', () => {
         return init(
             '<form id="FOo" method="GET"></form>',
             '<form id="FOo" method="get"></form>',
-            options
+            safePreset
         );
+    });
+
+    it('normalize invalid value default', () => {
+        return Promise.all([
+            // attribute on any tag
+            init(
+                '<img crossorigin="example">',
+                '<img crossorigin="anonymous">',
+                options
+            ),
+            // attribute on specific tag
+            init(
+                '<button type="example"></button><input type="example">',
+                // button has invalid default value for submit
+                // while input's invalid default value is ignored in out implementation
+                '<button type="submit"></button><input type="example">',
+                options
+            )
+        ]);
     });
 });

--- a/test/modules/removeRedundantAttributes.js
+++ b/test/modules/removeRedundantAttributes.js
@@ -110,20 +110,4 @@ describe('removeRedundantAttributes', () => {
             options
         );
     });
-
-    it('should remove preload="auto" from <audio> & <video>', () => {
-        return init(
-            '<audio src="example.com" preload="auto"></audio><video src="example.com" preload="auto"></video>',
-            '<audio src="example.com" preload=""></audio><video src="example.com" preload=""></video>',
-            options
-        );
-    });
-
-    it('should not remove preload="metadata" from <audio> & <video>', () => {
-        return init(
-            '<audio src="example.com" preload="metadata"></audio><video src="example.com" preload="metadata"></video>',
-            '<audio src="example.com" preload="metadata"></audio><video src="example.com" preload="metadata"></video>',
-            options
-        );
-    });
 });


### PR DESCRIPTION
The PR closes https://github.com/posthtml/htmlnano/issues/68

- Per HTML5 spec, the empty string value attribute can be collapsed (`[a=""] => [a]`). 
- Add support for HTML5 spec's invalid value default normalization
- Make sure attributions are normalized before being collapsed.
- `custom` plugin will be the last to applied.

The docs are also updated. Now the order of modules' documentation are sorted.

The PR should also further increases the minify rate. The benchmark might need an update as well.