### PR TITLE
Fixing Configuration File Typo

### DIFF
--- a/docs/versioned_docs/version-2.0.0/030-config.md
+++ b/docs/versioned_docs/version-2.0.0/030-config.md
@@ -6,7 +6,7 @@ There are two main ways to configure htmlnano:
 This is the way described above in the examples.
 
 ## Using configuration file
-Alternatively, you might create a configuration file (e.g., `htmlanorc.json` or `htmlnanorc.js`) or save options to `package.json` with `htmlnano` key.
+Alternatively, you might create a configuration file (e.g., `htmlnanorc.json` or `htmlnanorc.js`) or save options to `package.json` with `htmlnano` key.
 `htmlnano` uses `cosmiconfig`, so refer to [its documentation](https://github.com/davidtheclark/cosmiconfig/blob/main/README.md) for a more detailed description.
 
 If you want to specify a preset that way, use `preset` key:


### PR DESCRIPTION
There's a typo in 030-config.md for the configuration file "htmlanorc.json". This PR simply fixes said typo.
