### PR TITLE
Fix(#197): do not choke on svg error

### DIFF
--- a/lib/modules/minifySvg.es6
+++ b/lib/modules/minifySvg.es6
@@ -9,6 +9,18 @@ export default function minifySvg(tree, options, svgoOptions = {}) {
     tree.match({tag: 'svg'}, node => {
         let svgStr = tree.render(node, { closingSingleTag: 'slash', quoteAllAttributes: true });
         const result = svgo.optimize(svgStr, svgoOptions);
+
+        if (result.error) {
+            console.error('htmlnano fails to minify the svg:');
+            console.error(result.error);
+            if (result.modernError) {
+                console.error(result.modernError);
+            }
+
+            // We return the node as-is
+            return node;
+        }
+
         node.tag = false;
         node.attrs = {};
         // result.data is a string, we need to cast it to an array

--- a/test/modules/minifySvg.js
+++ b/test/modules/minifySvg.js
@@ -110,4 +110,21 @@ describe('minifySvg', () => {
             options
         );
     });
+
+    // https://github.com/posthtml/htmlnano/issues/197
+    it('shouldn\'t choke on svg errors', () => {
+        const input = `
+        <!doctype html>
+        <svg viewBox="0 0 100 100">
+            <text x="20" y="20" style="fill: black;">&cross;</text>
+        </svg>
+        `;
+        return init(
+            input,
+            input,
+            {
+                minifySvg: {}
+            }
+        );
+    });
 });


### PR DESCRIPTION
The PR fixes #197.

htmlnano will return the SVG node as is when svgo encounters an error, and show error information to `stderr`.