### PR TITLE
Fix js minify attrs value

### DIFF
--- a/lib/modules/minifyJs.es6
+++ b/lib/modules/minifyJs.es6
@@ -74,8 +74,8 @@ function processScriptNode(scriptNode, terserOptions) {
 
 
 function processNodeWithOnAttrs(node, terserOptions) {
-    const jsWrapperStart = 'function a(){';
-    const jsWrapperEnd = '}a();';
+    const jsWrapperStart = 'a=function(){';
+    const jsWrapperEnd = '};a();';
 
     const promises = [];
     for (const attrName of Object.keys(node.attrs || {})) {

--- a/test/modules/minifyJs.js
+++ b/test/modules/minifyJs.js
@@ -47,6 +47,22 @@ describe('minifyJs', () => {
         );
     });
 
+    it('should minify JS with `this` inside on* attributes ', () => {
+        return init(
+            '<video oncanplay="this.currentTime = 1.2; this.oncanplay=null;"></video>',
+            '<video oncanplay="this.currentTime=1.2,this.oncanplay=null"></video>',
+            options
+        );
+    });
+
+    it('should minify JS with `this` inside on* attributes with `module` option', () => {
+        return init(
+            '<video oncanplay="this.currentTime = 1.2; this.oncanplay=null;"></video>',
+            '<video oncanplay="this.currentTime=1.2,this.oncanplay=null"></video>',
+            {minifyJs: { module: true }}
+        );
+    });
+
     it('should not minify JS inside HTML comments', () => {
         return init(
             '<div><!-- <script> var foob = function () {}; </script> --></div>',


### PR DESCRIPTION
When minify JS with options `minifyJs: { module: true }` then it minifies the attrs wrapper functions too.

from `function a(){ ... }a();` to `!function(){ ... }()`

It broke the code because the wrapper function changes the length

source:
```html
<video oncanplay="this.currentTime = 1.2; this.oncanplay=null;"></video>
```

minify: (cut off the first and the list symbol)
```html
<video oncanplay="his.currentTime=1.2,this.oncanplay=nul"></video>
```

To fix, use a function expression. It doesn't change by minification