### PR TITLE
fix(#220): skip <script> and <style> with SRI

### DIFF
--- a/lib/modules/mergeScripts.es6
+++ b/lib/modules/mergeScripts.es6
@@ -1,11 +1,15 @@
 /* Merge multiple <script> into one */
-export default function mergeScripts(tree) {
+export default function mergeScripts (tree) {
     let scriptNodesIndex = {};
     let scriptSrcIndex = 1;
 
-    tree.match({tag: 'script'}, node => {
+    tree.match({ tag: 'script' }, node => {
         const nodeAttrs = node.attrs || {};
-        if (nodeAttrs.src) {
+        if (
+            'src' in nodeAttrs
+            // Skip SRI
+            || 'integrity' in nodeAttrs
+        ) {
             scriptSrcIndex++;
             return node;
         }
@@ -23,7 +27,7 @@ export default function mergeScripts(tree) {
             async: nodeAttrs.async !== undefined,
             index: scriptSrcIndex,
         });
-        if (! scriptNodesIndex[scriptKey]) {
+        if (!scriptNodesIndex[scriptKey]) {
             scriptNodesIndex[scriptKey] = [];
         }
 

--- a/lib/modules/mergeScripts.es6
+++ b/lib/modules/mergeScripts.es6
@@ -7,7 +7,7 @@ export default function mergeScripts (tree) {
         const nodeAttrs = node.attrs || {};
         if (
             'src' in nodeAttrs
-            // Skip SRI
+            // Skip SRI, reasons are documented in "minifyJs" module
             || 'integrity' in nodeAttrs
         ) {
             scriptSrcIndex++;

--- a/lib/modules/mergeStyles.es6
+++ b/lib/modules/mergeStyles.es6
@@ -8,7 +8,8 @@ export default function mergeStyles(tree) {
         const nodeAttrs = node.attrs || {};
         // Skip <style scoped></style>
         // https://developer.mozilla.org/en/docs/Web/HTML/Element/style
-        // Also skip SRI
+        //
+        // Also skip SRI, reasons are documented in "minifyJs" module
         if ('scoped' in nodeAttrs || 'integrity' in nodeAttrs) {
             return node;
         }

--- a/lib/modules/mergeStyles.es6
+++ b/lib/modules/mergeStyles.es6
@@ -8,7 +8,8 @@ export default function mergeStyles(tree) {
         const nodeAttrs = node.attrs || {};
         // Skip <style scoped></style>
         // https://developer.mozilla.org/en/docs/Web/HTML/Element/style
-        if (nodeAttrs.scoped !== undefined) {
+        // Also skip SRI
+        if ('scoped' in nodeAttrs || 'integrity' in nodeAttrs) {
             return node;
         }
 

--- a/lib/modules/minifyCss.es6
+++ b/lib/modules/minifyCss.es6
@@ -18,6 +18,10 @@ export default function minifyCss(tree, options, cssnanoOptions) {
 
     let promises = [];
     tree.walk(node => {
+        if (node.attrs && 'integrity' in node.attrs) {
+            return node;
+        }
+
         if (isStyleNode(node)) {
             promises.push(processStyleNode(node, cssnanoOptions));
         } else if (node.attrs && node.attrs.style) {

--- a/lib/modules/minifyCss.es6
+++ b/lib/modules/minifyCss.es6
@@ -18,6 +18,7 @@ export default function minifyCss(tree, options, cssnanoOptions) {
 
     let promises = [];
     tree.walk(node => {
+        // Skip SRI, reasons are documented in "minifyJs" module
         if (node.attrs && 'integrity' in node.attrs) {
             return node;
         }

--- a/lib/modules/minifyJs.es6
+++ b/lib/modules/minifyJs.es6
@@ -10,6 +10,19 @@ export default function minifyJs (tree, options, terserOptions) {
     let promises = [];
     tree.walk(node => {
         const nodeAttrs = node.attrs || {};
+
+        /**
+         * Skip SRI
+         *
+         * If the input <script /> has an SRI attribute, it means that the original <script /> could be trusted,
+         * and should not be altered anymore.
+         *
+         * htmlnano is exactly an MITM that SRI is designed to protect from. If htmlnano or its dependencies get
+         * compromised and introduces malicious code, then it is up to the original SRI to protect the end user.
+         *
+         * So htmlnano will simply skip <script /> that has SRI.
+         * If developers do trust htmlnano, they should generate SRI after htmlnano modify the <script />.
+         */
         if ('integrity' in nodeAttrs) {
             return node;
         }

--- a/lib/modules/minifyJs.es6
+++ b/lib/modules/minifyJs.es6
@@ -4,13 +4,17 @@ import { redundantScriptTypes } from './removeRedundantAttributes';
 const terser = optionalRequire('terser');
 
 /** Minify JS with Terser */
-export default function minifyJs(tree, options, terserOptions) {
+export default function minifyJs (tree, options, terserOptions) {
     if (!terser) return tree;
 
     let promises = [];
     tree.walk(node => {
+        const nodeAttrs = node.attrs || {};
+        if ('integrity' in nodeAttrs) {
+            return node;
+        }
+
         if (node.tag && node.tag === 'script') {
-            const nodeAttrs = node.attrs || {};
             const mimeType = nodeAttrs.type || 'text/javascript';
             if (redundantScriptTypes.has(mimeType) || mimeType === 'module') {
                 promises.push(processScriptNode(node, terserOptions));
@@ -28,7 +32,7 @@ export default function minifyJs(tree, options, terserOptions) {
 }
 
 
-function stripCdata(js) {
+function stripCdata (js) {
     const leftStrippedJs = js.replace(/\/\/\s*<!\[CDATA\[/, '').replace(/\/\*\s*<!\[CDATA\[\s*\*\//, '');
     if (leftStrippedJs === js) {
         return js;
@@ -39,7 +43,7 @@ function stripCdata(js) {
 }
 
 
-function processScriptNode(scriptNode, terserOptions) {
+function processScriptNode (scriptNode, terserOptions) {
     let js = (scriptNode.content || []).join('').trim();
     if (!js) {
         return scriptNode;
@@ -73,7 +77,7 @@ function processScriptNode(scriptNode, terserOptions) {
 }
 
 
-function processNodeWithOnAttrs(node, terserOptions) {
+function processNodeWithOnAttrs (node, terserOptions) {
     const jsWrapperStart = 'a=function(){';
     const jsWrapperEnd = '};a();';
 

--- a/lib/modules/minifyJson.es6
+++ b/lib/modules/minifyJson.es6
@@ -2,6 +2,11 @@ const rNodeAttrsTypeJson = /(\/|\+)json/;
 
 export function onContent() {
     return (content, node) => {
+        // Skip SRI
+        if (node.attrs && 'integrity' in node.attrs) {
+            return content;
+        }
+
         if (node.attrs && node.attrs.type && rNodeAttrsTypeJson.test(node.attrs.type)) {
             try {
                 // cast minified JSON to an array

--- a/lib/modules/minifyJson.es6
+++ b/lib/modules/minifyJson.es6
@@ -2,7 +2,7 @@ const rNodeAttrsTypeJson = /(\/|\+)json/;
 
 export function onContent() {
     return (content, node) => {
-        // Skip SRI
+        // Skip SRI, reasons are documented in "minifyJs" module
         if (node.attrs && 'integrity' in node.attrs) {
             return content;
         }

--- a/test/modules/mergeScripts.js
+++ b/test/modules/mergeScripts.js
@@ -72,4 +72,17 @@ describe('mergeScripts', () => {
             options
         );
     });
+
+    it('should not merge script with SRI', () => {
+        return init(
+            `<script>window.foo1 = 'foo'</script><script>window.foo2 = 'foo'</script>
+            <script integrity="example">window.foo2 = 'foo'</script><script>window.foo3 = 'baz'</script>
+            <script>window.bar1 = 'foo'</script><script>window.bar2 = 'bar'</script>`,
+
+            `<script>window.foo1 = 'foo';window.foo2 = 'foo'</script>
+            <script integrity="example">window.foo2 = 'foo'</script>
+            <script>window.foo3 = 'baz';window.bar1 = 'foo';window.bar2 = 'bar'</script>`,
+            options
+        );
+    });
 });

--- a/test/modules/mergeStyles.js
+++ b/test/modules/mergeStyles.js
@@ -33,6 +33,15 @@ describe('mergeStyles', () => {
         );
     });
 
+    it('should skip <style> with SRI', () => {
+        const html = `<style>h1 { color: red }</style>
+                      <div></div>
+                      <style integrity="example">div { color: blue }</style>`;
+        return init(
+            html, html, options
+        );
+    });
+
 
     it('should preserve amp-custom', () => {
         return init(

--- a/test/modules/minifyCss.js
+++ b/test/modules/minifyCss.js
@@ -36,6 +36,23 @@ describe('minifyCss', function () {
         );
     });
 
+    it('should not minify CSS inside <style> + SRI', () => {
+        const html = `<div><style integrity="example">
+        h1 {
+            margin: 10px 10px 10px 10px;
+            color: #ff0000;
+            -moz-border-radius: 10px;
+            border-radius: 10px;
+        }
+    </style></div>`;
+        return init(
+            html,
+            html,
+            options
+        );
+    });
+
+
 
     it('should minify CSS inside style attribute', () => {
         return init(

--- a/test/modules/minifyJs.js
+++ b/test/modules/minifyJs.js
@@ -28,6 +28,25 @@ describe('minifyJs', () => {
         );
     });
 
+    it('should not minify JS with <script> + SRI', () => {
+        return init(
+            `<div>
+                <script integrity="example"> /* test */ var foob = function () {}; </script>
+                <script integrity="example" type="module"> /* test */ var foob = function () {}; </script>
+                <script integrity="example" type="text/javascript"> /* test */ var foob = function () {}; </script>
+                <script integrity="example" type="application/javascript"> /* test */ var foob = function () {}; </script>
+             </div>`,
+            `<div>
+                <script integrity="example"> /* test */ var foob = function () {}; </script>
+                <script integrity="example" type="module"> /* test */ var foob = function () {}; </script>
+                <script integrity="example" type="text/javascript"> /* test */ var foob = function () {}; </script>
+                <script integrity="example" type="application/javascript"> /* test */ var foob = function () {}; </script>
+             </div>`,
+            options
+        );
+    });
+
+
     it('should minify ES6 inside <script>', () => {
         return init(
             `<script>

--- a/test/modules/minifyJson.js
+++ b/test/modules/minifyJson.js
@@ -26,6 +26,25 @@ describe('minifyJson', () => {
         );
     });
 
+    it('should skip JSON inside <script> tags with SRI', () => {
+        const fixtures = `<script type="application/json" integrity="example">
+                {
+                    "test": 5
+                }
+             </script>
+             <script type="application/ld+json" integrity="example">
+                {
+                    "test": 6
+                }
+             </script>`;
+
+        return init(
+            fixtures,
+            fixtures,
+            options
+        );
+    });
+
     it('should skip <script> tags with non-JSON mime type', () => {
         return init(
             '<script>{"test": 5}</script>',


### PR DESCRIPTION
The PR fixes #220.

The PR makes htmlnano skip any `<script />` and `<style />` tags that have SRI attributes, including `minifyJs`, `minifyCss`, `minifyJson`, `mergeStyles` and `mergeScripts`.
The reason behind the change is documented in the comment, and test cases about the change are also added.