### PR TITLE
remove `skipConfigLoading` from options after used.

### DIFF
--- a/lib/htmlnano.es6
+++ b/lib/htmlnano.es6
@@ -12,7 +12,9 @@ const presets = {
 };
 
 export function loadConfig(options, preset, configPath) {
-    if (!options?.skipConfigLoading) {
+    let { skipConfigLoading = false, ...rest } = options || {};
+
+    if (!skipConfigLoading) {
         const explorer = cosmiconfigSync(packageJson.name);
         const rc = configPath ? explorer.load(configPath) : explorer.search();
         if (rc) {
@@ -26,15 +28,13 @@ export function loadConfig(options, preset, configPath) {
             }
 
             if (!options) {
-                options = rc.config;
+                rest = rc.config;
             }
         }
     }
 
-    delete options?.skipConfigLoading;
-
     return [
-        options || {},
+        rest || {},
         preset || safePreset,
     ];
 }

--- a/lib/htmlnano.es6
+++ b/lib/htmlnano.es6
@@ -31,6 +31,8 @@ export function loadConfig(options, preset, configPath) {
         }
     }
 
+    delete options?.skipConfigLoading;
+
     return [
         options || {},
         preset || safePreset,

--- a/test/htmlnano.js
+++ b/test/htmlnano.js
@@ -40,6 +40,10 @@ describe('[htmlnano]', () => {
                 code: '<div></div>'
             }));
     });
+
+    it('should not treat skipConfigLoading as a module name', () => {
+        return init('<div></div>', '<div></div>', { skipConfigLoading: true });
+    });
 });
 
 
@@ -66,10 +70,11 @@ describe('loadConfig()', () => {
     });
 
     it('should not load options and preset from RC files if skipConfigLoading is true', () => {
-        expect(loadConfig({ skipConfigLoading: true }, undefined, './test/testrc.json')).toEqual([
-            {},
-            safePreset
-        ]);
+        const options = { skipConfigLoading: true };
+        const loaded = loadConfig(options, undefined, './test/testrc.json');
+
+        expect(loaded).toEqual([{}, safePreset]);
+        expect(options).toEqual({ skipConfigLoading: true });
     });
 });
 

--- a/test/htmlnano.js
+++ b/test/htmlnano.js
@@ -67,7 +67,7 @@ describe('loadConfig()', () => {
 
     it('should not load options and preset from RC files if skipConfigLoading is true', () => {
         expect(loadConfig({ skipConfigLoading: true }, undefined, './test/testrc.json')).toEqual([
-            { skipConfigLoading: true },
+            {},
             safePreset
         ]);
     });


### PR DESCRIPTION
Fix `Module "skipConfigLoading" is not defined` error when run:

```javascript
htmlnano.process(html, { skipConfigLoading: true });
```
