### PR TITLE
Update peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "uncss": "^0.17.3"
   },
   "peerDependencies": {
-    "cssnano": "^5.0.11",
+    "cssnano": "^5.0.11 || ^6.0.0",
     "postcss": "^8.3.11",
     "purgecss": "^5.0.0",
     "relateurl": "^0.2.7",


### PR DESCRIPTION
Allow using `cssnano@6.0.0`.

When I try to use `cssnano@6.0.0` in my package dependencies

```json
  "dependencies": {
    ...
    "cssnano": "^6.0.0",
    ...
    "htmlnano": "^2.0.3",
    ...
  }
```
I see the following error in the console

```bash
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: htmlnano@2.0.3
npm ERR! Found: cssnano@6.0.0
npm ERR! node_modules/cssnano
npm ERR!   cssnano@"^6.0.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peerOptional cssnano@"^5.0.11" from htmlnano@2.0.3
npm ERR! node_modules/htmlnano
npm ERR!   htmlnano@"^2.0.3" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: cssnano@5.1.15
npm ERR! node_modules/cssnano
npm ERR!   peerOptional cssnano@"^5.0.11" from htmlnano@2.0.3
npm ERR!   node_modules/htmlnano
npm ERR!     htmlnano@"^2.0.3" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```