### PR TITLE
collapse whitespace according to spec

### DIFF
--- a/lib/modules/collapseWhitespace.es6
+++ b/lib/modules/collapseWhitespace.es6
@@ -21,7 +21,8 @@ const noTrimWhitespacesInsideElements = new Set([
 
 const startsWithWhitespacePattern = /^\s/;
 const endsWithWhitespacePattern = /\s$/;
-const multipleWhitespacePattern = /\s+/g;
+// See https://infra.spec.whatwg.org/#strip-and-collapse-ascii-whitespace and https://infra.spec.whatwg.org/#ascii-whitespace
+const multipleWhitespacePattern = /[\t\n\f\r ]{2,}/g;
 const NONE = '';
 const SINGLE_SPACE = ' ';
 const validOptions = ['all', 'aggressive', 'conservative'];


### PR DESCRIPTION
This prevents replacement of significant (non-ASCII) whitespace like (non-entity-encoded) non-breaking spaces, etc.