### PR TITLE
fix: fix downlevel-revealed closing comment being deleted in safe mode

### DIFF
--- a/lib/helpers.mjs
+++ b/lib/helpers.mjs
@@ -24,7 +24,8 @@ export function isComment(content) {
 }
 
 export function isConditionalComment(content) {
-    return (content || '').trim().startsWith('<!--[if');
+    const clean = (content || '').trim();
+    return clean.startsWith('<!--[if') || clean === '<!--<![endif]-->';
 }
 
 export function isStyleNode(node) {

--- a/test/modules/minifyConditionalComments.mjs
+++ b/test/modules/minifyConditionalComments.mjs
@@ -41,7 +41,7 @@ describe('minifyConditionalComments', () => {
     <div class="w3c">
     </div>
 <!--<![endif]-->`,
-        multipleConditionalCommentMinified: '<!--[if lt IE 7 ]><div class="ie6"> </div><![endif]--><!--[if IE 7 ]><div class="ie7"> </div><![endif]--><!--[if IE 8 ]><div class="ie8"> </div><![endif]--><!--[if IE 9 ]><div class="ie9"> </div><![endif]--><!--[if (gt IE 9)|!(IE)]><!--><div class="w3c"> </div>',
+        multipleConditionalCommentMinified: '<!--[if lt IE 7 ]><div class="ie6"> </div><![endif]--><!--[if IE 7 ]><div class="ie7"> </div><![endif]--><!--[if IE 8 ]><div class="ie8"> </div><![endif]--><!--[if IE 9 ]><div class="ie9"> </div><![endif]--><!--[if (gt IE 9)|!(IE)]><!--><div class="w3c"> </div><!--<![endif]-->',
         singleLineMultipleConditionalComment: `
 <!--[if lt IE 7 ]><div class="ie6"></div><![endif]--><!--[if IE 7 ]><div class="ie7"></div><![endif]--><!--[if IE 8 ]><div class="ie8"></div><![endif]--><!--[if IE 9 ]><div class="ie9"></div><![endif]--><!--[if (gt IE 9)|!(IE)]><!--><div class="w3c"></div><!--<![endif]-->`,
         htmlTagIncludedConditionalComment: `

--- a/test/modules/removeComments.mjs
+++ b/test/modules/removeComments.mjs
@@ -33,6 +33,14 @@ describe('removeComments', () => {
             );
         });
 
+        it('should not remove conditional comments <!--[if expression]><!-->..<!--<![endif]-->', () => {
+            return init(
+                '<!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->',
+                '<!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->',
+                options
+            );
+        });
+
         it('should not remove conditional comments <!--[if expression]>..<![endif]-->', () => {
             return init(
                 '<!--[if IE 8]><link href="ie8only.css" rel="stylesheet"><![endif]-->',


### PR DESCRIPTION
The closing comment for [downlevel-revealed closing comments](https://en.wikipedia.org/wiki/Conditional_comment#Downlevel-revealed_conditional_comment) were being deleted in safe mode. Added one more test and fixed a falsely passing test.

I'm using htmlnano for minifying the output from mjml and noticed that even in safemode, the closing comments for some conditional comments were being removed.