### PR TITLE
fix: add missing argument in typescript definition of removeComments

### DIFF
--- a/docs/docs/050-modules.md
+++ b/docs/docs/050-modules.md
@@ -414,8 +414,8 @@ Source:
 
 ```js
 {
-    removeComments: (comments) => {
-        if (comments.includes('noindex')) return true;
+    removeComments: (comment) => {
+        if (comment.includes('noindex')) return true;
         return false;
     }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ export interface HtmlnanoOptions {
   minifySvg?: SvgoOptimizeOptions | boolean;
   normalizeAttributeValues?: boolean;
   removeAttributeQuotes?: boolean;
-  removeComments?: boolean | "safe" | "all" | RegExp | (() => boolean);
+  removeComments?: boolean | "safe" | "all" | RegExp | ((comment: string) => boolean);
   removeEmptyAttributes?: boolean;
   removeRedundantAttributes?: boolean;
   removeOptionalTags?: boolean;

--- a/test/modules/removeComments.mjs
+++ b/test/modules/removeComments.mjs
@@ -122,8 +122,8 @@ describe('removeComments', () => {
                 '<!--noindex-->this text will not be indexed<!--/noindex-->Lorem ipsum dolor sit amet<!--more-->Lorem ipsum dolor sit amet',
                 'this text will not be indexedLorem ipsum dolor sit amet<!--more-->Lorem ipsum dolor sit amet',
                 {
-                    removeComments: (comments) => {
-                        if (comments.includes('noindex')) return true;
+                    removeComments: (comment) => {
+                        if (comment.includes('noindex')) return true;
                         return false;
                     },
                 }


### PR DESCRIPTION
According to tests and documentation, the `comment` argument is missing from the TypeScript definition of the `removeComments` option.

https://github.com/posthtml/htmlnano/blob/151da26bf6b1e82e380ace889bcf8da6e34f7976/test/modules/removeComments.mjs#L125-L128

https://github.com/posthtml/htmlnano/blob/151da26bf6b1e82e380ace889bcf8da6e34f7976/index.d.ts#L25

Also, I used the singular form since each comment is processed individually.