### PR TITLE
fix(types): add exports to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,16 @@
   "source": "index.mjs",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "require": "./index.cjs",
       "import": "./index.mjs"
     },
     "./index.mjs": {
+      "types": "./index.d.mts",
       "import": "./index.mjs"
     },
     "./index.cjs": {
+      "types": "./index.d.cts",
       "require": "./index.cjs"
     }
   },


### PR DESCRIPTION
Ran into #270 myself; I'm not a user of Typescript directly, but I do grab types using JSDoc comments to help in my IDE. Did some research, apparently you have to declare explicit type exports in `package.json`.

Specifically, I followed the work done in this comment here: https://github.com/tj/commander.js/pull/1704#issuecomment-1070359858. I then did a local install to verify type accquisition works as intended and it appears to. Hopefully this pull request fixes it!