### PR TITLE
feat: add skipInternalWarnings flag to avoid console.warn output

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ import type { Config as SvgoOptimizeOptions } from "svgo";
 
 export interface HtmlnanoOptions {
   skipConfigLoading?: boolean;
+  skipInternalWarnings?: boolean;
   collapseAttributeWhitespace?: boolean;
   collapseBooleanAttributes?: {
     amphtml?: boolean;

--- a/lib/htmlnano.mjs
+++ b/lib/htmlnano.mjs
@@ -98,7 +98,9 @@ function htmlnano(optionsRun, presetRun) {
                     await import(dependency);
                 } catch (e) {
                     if (e.code === 'MODULE_NOT_FOUND' || e.code === 'ERR_MODULE_NOT_FOUND') {
-                        console.warn(`You have to install "${dependency}" in order to use htmlnano's "${moduleName}" module`);
+                        if (!options.skipInternalWarnings){
+                            console.warn(`You have to install "${dependency}" in order to use htmlnano's "${moduleName}" module`);
+                        }
                     } else {
                         throw e;
                     }


### PR DESCRIPTION
motivation:

I'm using htmlnano with AWS Lambda, where the `console.warn` shows in unit tests and AWS cloudwatch. To suppress them, an optional flag is required