### PR TITLE
perf: replace timsort with timsort2

### DIFF
--- a/lib/modules/sortAttributes.mjs
+++ b/lib/modules/sortAttributes.mjs
@@ -1,4 +1,4 @@
-import { sort as timSort } from 'timsort';
+import { sort as timSort } from 'timsort2';
 
 const validOptions = new Set(['frequency', 'alphabetical']);
 

--- a/lib/modules/sortAttributesWithLists.mjs
+++ b/lib/modules/sortAttributesWithLists.mjs
@@ -1,5 +1,5 @@
 // class, rel, ping
-import { sort as timSort } from 'timsort';
+import { sort as timSort } from 'timsort2';
 import { attributesWithLists } from './collapseAttributeWhitespace.mjs';
 
 const validOptions = new Set(['frequency', 'alphabetical']);

--- a/package.json
+++ b/package.json
@@ -64,15 +64,15 @@
   "dependencies": {
     "cosmiconfig": "^9.0.0",
     "posthtml": "^0.16.5",
-    "timsort": "^0.3.0"
+    "timsort2": "^1.0.0"
   },
   "devDependencies": {
+    "@aminya/babel-plugin-replace-import-extension": "1.2.0",
     "@babel/cli": "^7.15.7",
     "@babel/core": "^7.15.5",
     "@babel/eslint-parser": "^7.17.0",
     "@babel/preset-env": "^7.15.6",
     "@babel/register": "^7.15.3",
-    "@aminya/babel-plugin-replace-import-extension": "1.2.0",
     "cssnano": "^7.0.0",
     "eslint": "^8.12.0",
     "eslint-plugin-import": "^2.28.1",


### PR DESCRIPTION
As a weekend project, I've decided to update, optimize and overhaul one of the dependencies I use in my own private projects: [`timsort`](https://www.npmjs.com/package/timsort). I managed to reduce the package size by 33% and speed it up by 5% - 50%. Since `timsort` is abadoned, I've published the update as [`timsort2`](https://www.npmjs.com/package/timsort2).

This PR intends to update the performance of this project (and maybe get feedback) with `timsort2`. Since I can't build or test this project due to `rimraf` errors, I can't really test if everything works, but since all `timsort` tests pass, I don't think it's going to be a big problem.