### PR TITLE
chore: fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![npm version](https://badge.fury.io/js/htmlnano.svg)](http://badge.fury.io/js/htmlnano)
 ![CI](https://github.com/posthtml/htmlnano/actions/workflows/ci.yml/badge.svg)
 
-Modular HTML minifier, built on top of the [PostHTML](https://github.com/posthtml/posthtml). Inspired by [cssnano](http://cssnano.co/).
+Modular HTML minifier, built on top of the [PostHTML](https://github.com/posthtml/posthtml). Inspired by [cssnano](https://github.com/cssnano/cssnano).
 
 ## [Benchmark](https://github.com/maltsev/html-minifiers-benchmark/blob/master/README.md)
 [html-minifier-terser@6.0.2]: https://www.npmjs.com/package/html-minifier-terser


### PR DESCRIPTION
`http://cssnano.co/` was dead