### PR TITLE
fix(#376): use `Object.assign` trick to avoid `namespace` types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ const modules = {
     sortAttributesWithLists: () => interop(import('./_modules/sortAttributesWithLists.js'))
 } satisfies Record<string, () => Promise<HtmlnanoModule<any>>>;
 
-export function htmlnano(optionsRun: HtmlnanoOptions = {}, presetRun?: HtmlnanoPreset) {
+const htmlnano = Object.assign(function htmlnano(optionsRun: HtmlnanoOptions = {}, presetRun?: HtmlnanoPreset) {
     // eslint-disable-next-line prefer-const -- re-assign options
     let [options, preset] = loadConfig(optionsRun, presetRun);
 
@@ -191,7 +191,13 @@ export function htmlnano(optionsRun: HtmlnanoOptions = {}, presetRun?: HtmlnanoP
     };
 
     return minifier;
-}
+}, {
+    presets,
+    getRequiredOptionalDependencies,
+    process,
+    htmlMinimizerWebpackPluginMinify,
+    loadConfig
+});
 
 export function getRequiredOptionalDependencies(optionsRun: HtmlnanoOptions, presetRun: HtmlnanoPreset) {
     const [options] = loadConfig(optionsRun, presetRun);
@@ -225,19 +231,13 @@ export function htmlMinimizerWebpackPluginMinify(
     minimizerOptions?: HtmlnanoOptions
 ) {
     const [[, code]] = Object.entries(input);
-    return htmlnano.process(code, minimizerOptions, presets.safe)
+    return process(code, minimizerOptions, presets.safe)
         .then((result) => {
             return {
                 code: result.html
             };
         });
 }
-
-htmlnano.presets = presets;
-htmlnano.getRequiredOptionalDependencies = getRequiredOptionalDependencies;
-htmlnano.process = process;
-htmlnano.htmlMinimizerWebpackPluginMinify = htmlMinimizerWebpackPluginMinify;
-htmlnano.loadConfig = loadConfig;
 
 export default htmlnano;
 


### PR DESCRIPTION
Fixes #376.

To maintain backward compatibility, all named exports still need to be accessible on the main `htmlnano` function. It is done by manually assigning them to the main `htmlnano` function.

However, in this case, TypeScript will infer a `namespace` type, alongside `rollup-plugin-dts`, which generates a problematic `.d.ts` file with namespace methods referencing themselves. 

This PR instead uses `Object.assign`, and TypeScript now infers this as an intersection type, which is not a `namespace`, thus no wrongly self-referencing issue.

cc @danielroe.